### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "gather"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gather"
-version = "0.3.0"
+version = "0.3.1"
 description = "Gathers files from directories and subdirectories into a target directory."
 license = "Apache-2.0"
 authors = ["evensolberg <even.solberg@gmail.com>"]


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version from `0.3.0` → `0.3.1`
- Patch release for the gtr-b6p fix landed in PR #75: `-q` no longer silences `-p`/`--print-summary` output

## Test plan

- [x] `cargo build` confirms the new version compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)