### PR TITLE
refactor: anyhow error handling + extract process_file (gtr-jz8, gtr-3aa)

### DIFF
--- a/.crumbs/extract-per-file-processing-logic-into-a-dedicated-function.md
+++ b/.crumbs/extract-per-file-processing-logic-into-a-dedicated-function.md
@@ -1,7 +1,7 @@
 ---
 id: gtr-3aa
 title: Extract per-file processing logic into a dedicated function
-status: open
+status: closed
 type: task
 priority: 2
 tags:
@@ -9,7 +9,7 @@ tags:
 - readability
 - testability
 created: 2026-06-08
-updated: 2026-07-02
+updated: 2026-07-03
 phase: ''
 ---
 

--- a/.crumbs/replace-box-dyn-error-with-anyhow-error-for-richer-error-con.md
+++ b/.crumbs/replace-box-dyn-error-with-anyhow-error-for-richer-error-con.md
@@ -1,7 +1,7 @@
 ---
 id: gtr-jz8
 title: Replace Box<dyn Error> with anyhow::Error for richer error context
-status: open
+status: closed
 type: feature
 priority: 2
 tags:
@@ -9,7 +9,7 @@ tags:
 - anyhow
 - code-quality
 created: 2026-06-08
-updated: 2026-06-08
+updated: 2026-07-03
 phase: ''
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 name = "gather"
 version = "0.3.2"
 dependencies = [
+ "anyhow",
  "clap",
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities", "filesystem"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.6.1", features = ["cargo", "env", "wrap_help"] }
 env_logger = "0.11.10"
 log = "0.4.32"

--- a/docs/plans/2026-07-03-anyhow-migration.md
+++ b/docs/plans/2026-07-03-anyhow-migration.md
@@ -1,0 +1,376 @@
+# Anyhow Error Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `Box<dyn Error>` throughout with `anyhow::Error` so error call sites can attach human-readable context via `.with_context()` / `anyhow::bail!`.
+
+**Architecture:** Add `anyhow = "1"` as a dependency. Update the two files that deal in errors (`src/utils.rs` and `src/main.rs`) — changing return-type signatures, swapping `.into()` for `anyhow::bail!`, and using `.with_context()` in `check_directory` to embed the target path in the OS error. No behaviour change visible to end-users; all existing tests must remain green.
+
+**Tech Stack:** Rust 2021 edition · `anyhow 1.x`
+
+## Global Constraints
+
+- No behaviour changes — existing tests must remain green.
+- `clippy` must produce zero warnings (`cargo clippy -- -D warnings`).
+- `cargo fmt` before every commit.
+- Commit message format: `type(scope): description` with `Co-Authored-By: Claude <noreply@anthropic.com>`.
+- Run `/opt/homebrew/bin/git-mit es` before every commit if the binary is present.
+
+---
+
+### Task 1: Migrate `Box<dyn Error>` to `anyhow::Error`
+
+**Files:**
+- Modify: `Cargo.toml` (add dependency)
+- Modify: `src/utils.rs` (update `check_directory` signature + error construction)
+- Modify: `src/main.rs` (update `run()` signature + error constructions)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  // utils.rs
+  pub fn check_directory(target: &str) -> anyhow::Result<()>
+
+  // main.rs
+  fn run() -> anyhow::Result<()>
+  ```
+
+---
+
+- [ ] **Step 1: Add `anyhow` to `Cargo.toml`**
+
+In `Cargo.toml`, add `anyhow` to `[dependencies]` (keep alphabetical order):
+
+```toml
+[dependencies]
+anyhow = "1"
+clap = { version = "4.6.1", features = ["cargo", "env", "wrap_help"] }
+env_logger = "0.11.10"
+log = "0.4.32"
+```
+
+- [ ] **Step 2: Update `src/utils.rs`**
+
+Replace the entire file content with the following (the only changes are: add `use anyhow::Context;`, change `check_directory`'s return type, and update its two error-construction sites):
+
+```rust
+use anyhow::Context as _;
+use env_logger::{Builder, Target};
+use log::LevelFilter;
+
+/// Verify that the target is a directory.
+///
+/// # Arguments
+///
+/// - `target: &str` - a string containing the path to whatever we want to check.
+///
+/// # Returns
+///
+/// - `anyhow::Result<()>` - returns an empty `Ok()` if it is a directory, or an
+///   error (with the target path embedded) if not.
+pub fn check_directory(target: &str) -> anyhow::Result<()> {
+    let metadata = std::fs::metadata(target)
+        .with_context(|| format!("Target directory '{target}'"))?;
+    if !metadata.is_dir() {
+        anyhow::bail!("Specified target is not a directory. Unable to proceed.");
+    }
+    log::debug!("Specified target is a directory. Proceeding.");
+
+    Ok(())
+}
+
+/// Determine the `LevelFilter` from parsed flag values.
+///
+/// `quiet = true` suppresses all log output (`Off`). Otherwise `debug_count`
+/// selects the level: 0 → `Info`, 1 → `Debug`, 2+ → `Trace`.
+fn log_level(quiet: bool, debug_count: u8) -> LevelFilter {
+    if quiet {
+        LevelFilter::Off
+    } else {
+        match debug_count {
+            0 => LevelFilter::Info,
+            1 => LevelFilter::Debug,
+            _ => LevelFilter::Trace,
+        }
+    }
+}
+
+/// Build a logging configuration based on CLI input.
+pub fn log_build(cli_args: &clap::ArgMatches) {
+    // Route all log output to stdout so it shares the same fd as the
+    // println!-based summary output (see main.rs print_summary block).
+    // Both streams write to the same fd; the logger uses its own internal
+    // buffer while println! goes through Rust's LineWriter (line-flushed).
+    Builder::new()
+        .filter_level(log_level(
+            cli_args.get_flag("quiet"),
+            cli_args.get_count("debug"),
+        ))
+        .target(Target::Stdout)
+        .init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{check_directory, log_level};
+    use log::LevelFilter;
+
+    // ---------------------------------------------------------------------------
+    // check_directory
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn check_directory_accepts_real_temp_dir() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        assert!(
+            check_directory(dir.path().to_str().expect("non-UTF-8 temp path")).is_ok(),
+            "expected Ok for a real directory"
+        );
+    }
+
+    #[test]
+    fn check_directory_rejects_file_path() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let file_path = dir.path().join("dummy.txt");
+        std::fs::write(&file_path, b"data").expect("failed to write temp file");
+        let result = check_directory(file_path.to_str().expect("non-UTF-8 temp path"));
+        assert!(
+            result.is_err(),
+            "expected Err for a file path, not a directory"
+        );
+    }
+
+    #[test]
+    fn check_directory_rejects_nonexistent_path() {
+        // Join a never-created child name onto an existing tempdir — the child
+        // path is guaranteed absent without needing to drop the parent first.
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let absent = dir.path().join("does-not-exist");
+        let result = check_directory(absent.to_str().expect("non-UTF-8 temp path"));
+        assert!(result.is_err(), "expected Err for a nonexistent path");
+    }
+
+    // ---------------------------------------------------------------------------
+    // log_level
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn log_level_quiet_returns_off() {
+        assert_eq!(log_level(true, 0), LevelFilter::Off);
+    }
+
+    #[test]
+    fn log_level_no_flags_returns_info() {
+        assert_eq!(log_level(false, 0), LevelFilter::Info);
+    }
+
+    #[test]
+    fn log_level_one_debug_flag_returns_debug() {
+        assert_eq!(log_level(false, 1), LevelFilter::Debug);
+    }
+
+    #[test]
+    fn log_level_two_debug_flags_returns_trace() {
+        assert_eq!(log_level(false, 2), LevelFilter::Trace);
+    }
+
+    #[test]
+    fn log_level_three_debug_flags_also_returns_trace() {
+        // Confirms the wildcard arm covers all values above 1, not just exactly 2.
+        assert_eq!(log_level(false, 3), LevelFilter::Trace);
+    }
+}
+```
+
+- [ ] **Step 3: Update `src/main.rs`**
+
+Replace the entire file content with the following (changes: remove `use std::error::Error`, change `run()` return type, swap `Err(format!(...).into())` for `anyhow::bail!`):
+
+```rust
+mod cli;
+mod utils;
+
+use std::path::Path;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// This is where the magic happens.
+fn run() -> anyhow::Result<()> {
+    // Set up the command line. Ref https://docs.rs/clap for details.
+    let cli_args = cli::build();
+
+    // Set up logging
+    utils::log_build(&cli_args);
+
+    // create a list of the files to gather
+    let sources = cli_args
+        .get_many::<String>("read")
+        .unwrap_or_default()
+        .map(String::as_str);
+    log::debug!("files_to_gather: {sources:?}");
+
+    // Verify that the target exists and that it is a directory
+    let target_dir = cli_args.get_one::<String>("target").expect(
+        "default_value('.') guarantees target is always present — this is a clap bug if None",
+    );
+    log::trace!("target_dir: {target_dir:?}");
+    utils::check_directory(target_dir)?;
+
+    let move_files = cli_args.get_flag("move");
+    let stop_on_error = cli_args.get_flag("stop");
+    let show_detail_info = !cli_args.get_flag("detail-off");
+    let dry_run = cli_args.get_flag("dry-run");
+    let print_summary = cli_args.get_flag("summary");
+    log::debug!("move_files: {move_files}, stop_on_error: {stop_on_error}, show_detail_info: {show_detail_info}, dry_run: {dry_run}, print_summary: {print_summary}");
+
+    if dry_run {
+        // Write directly to stdout so the banner is never silenced by -q/--quiet.
+        // The quiet flag sets LevelFilter::Off; even log::error! is filtered out.
+        println!("Starting dry-run.");
+    }
+
+    let mut total_file_count: usize = 0;
+    let mut processed_file_count: usize = 0;
+    let mut skipped_file_count: usize = 0;
+
+    // Gather files
+    for source in sources {
+        total_file_count += 1;
+
+        // Paths ending in "/" or ".." have no filename component — treat like any other error.
+        let Some(file_name) = Path::new(source).file_name() else {
+            if stop_on_error {
+                anyhow::bail!("Error: Invalid filename in path: {source}. Halting.");
+            }
+            log::warn!("Invalid filename in path: {source}. Continuing.");
+            skipped_file_count += 1;
+            continue;
+        };
+
+        let new_filename = Path::new(target_dir).join(file_name);
+        let target = new_filename.display();
+
+        if dry_run {
+            // Write directly to stdout so previews are never silenced by -q/--quiet.
+            if move_files {
+                println!("  {source} --> {target}");
+            } else {
+                println!("  {source} ==> {target}");
+            }
+            processed_file_count += 1;
+        } else if move_files {
+            log::debug!("Moving {source} to {target}");
+            match std::fs::rename(source, &new_filename) {
+                Ok(()) => {
+                    if show_detail_info {
+                        log::info!("  {source} --> {target}");
+                    }
+                    processed_file_count += 1;
+                }
+                Err(err) => {
+                    if stop_on_error {
+                        anyhow::bail!(
+                            "Error: {err}. Unable to move {source} to {target}. Halting."
+                        );
+                    }
+                    log::warn!("Unable to move {source} to {target}. Continuing.");
+                    skipped_file_count += 1;
+                }
+            }
+        } else {
+            log::debug!("Copying {source} to {target}");
+            match std::fs::copy(source, &new_filename) {
+                Ok(_) => {
+                    if show_detail_info {
+                        log::info!("  {source} ==> {target}");
+                    }
+                    processed_file_count += 1;
+                }
+                Err(err) => {
+                    if stop_on_error {
+                        anyhow::bail!(
+                            "Error: {err}. Unable to copy {source} to {target}. Halting."
+                        );
+                    }
+                    log::warn!("Unable to copy {source} to {target}. Continuing.");
+                    skipped_file_count += 1;
+                }
+            }
+        } // if dry_run
+    } // for source
+
+    if print_summary {
+        // Write directly to stdout so the summary is never silenced by -q/--quiet.
+        println!("Total files examined:        {total_file_count:5}");
+        if move_files {
+            println!("Files moved:                 {processed_file_count:5}");
+        } else {
+            println!("Files copied:                {processed_file_count:5}");
+        }
+        println!("Files skipped due to errors: {skipped_file_count:5}");
+    }
+
+    Ok(())
+} // fn run()
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// The actual executable function that gets called when the program is invoked.
+fn main() -> std::process::ExitCode {
+    match run() {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run all tests**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo test 2>&1
+```
+
+Expected: all tests **PASS**.
+
+- [ ] **Step 5: Check clippy and formatting**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo fmt && cargo clippy -- -D warnings 2>&1
+```
+
+Expected: zero warnings, zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Volumes/SSD/Source/Rust/gather
+/opt/homebrew/bin/git-mit es 2>/dev/null || true
+git add Cargo.toml Cargo.lock src/utils.rs src/main.rs
+git commit -m "$(cat <<'EOF'
+feat(error): replace Box<dyn Error> with anyhow (gtr-jz8)
+
+Add anyhow = "1" and migrate all error return types to anyhow::Result.
+Swap Err(format!(...).into()) for anyhow::bail! and use .with_context()
+in check_directory to embed the target path in the OS error message.
+No behaviour changes; all existing tests pass.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 7: Close the crumb**
+
+```bash
+/Users/evensolberg/.cargo/bin/crumbs close gtr-jz8
+git add .crumbs/replace-box-dyn-error-with-anyhow-error-for-richer-error-con.md
+git commit -m "$(cat <<'EOF'
+chore(crumbs): close gtr-jz8 — anyhow migration complete
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```

--- a/docs/plans/2026-07-03-extract-process-file.md
+++ b/docs/plans/2026-07-03-extract-process-file.md
@@ -1,0 +1,498 @@
+# Extract `process_file` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the `dry_run / move / copy` per-file dispatch block from `run()` into a standalone, unit-testable `process_file` function.
+
+**Architecture:** Add a `ProcessOptions` struct and `pub fn process_file` to `src/utils.rs` (alongside the existing `check_directory` helper). `run()` in `src/main.rs` constructs a `ProcessOptions`, then calls `utils::process_file` inside the for-loop instead of the inline if/else chain. No new files; no new dependencies (anyhow already added by gtr-jz8).
+
+**Tech Stack:** Rust 2021 edition · `anyhow 1.x` (already a dependency) · `tempfile` (already a dev-dependency) for unit-test fixtures · `cargo test` (unit + integration)
+
+## Global Constraints
+
+- All existing tests must remain green — this is a pure refactoring, no behaviour changes.
+- No new crate dependencies.
+- `clippy` must produce zero warnings (`cargo clippy -- -D warnings`).
+- `cargo fmt` before every commit.
+- Commit message format: `type(scope): description` with `Co-Authored-By: Claude <noreply@anthropic.com>`.
+- Run `/opt/homebrew/bin/git-mit es` before every commit if the binary is present.
+
+---
+
+### Task 1: Add `ProcessOptions` and `process_file` to `utils.rs`
+
+**Files:**
+- Modify: `src/utils.rs` (add struct + function + unit tests)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct ProcessOptions {
+      pub dry_run: bool,
+      pub move_files: bool,
+      pub stop_on_error: bool,
+      pub show_detail_info: bool,
+  }
+
+  pub fn process_file(
+      source: &str,
+      target: &std::path::Path,
+      opts: &ProcessOptions,
+  ) -> anyhow::Result<bool>
+  ```
+  `Ok(true)` = file was processed; `Ok(false)` = file was skipped (soft error); `Err(...)` = hard stop.
+
+---
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Add the following block at the **end** of the `#[cfg(test)]` module in `src/utils.rs`
+(after the existing `log_level_*` tests, before the closing `}`):
+
+```rust
+// ---------------------------------------------------------------------------
+// process_file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn process_file_dry_run_copy_returns_ok_true_without_creating_file() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("in.txt");
+    std::fs::write(&src, b"data").expect("write src");
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: true,
+        move_files: false,
+        stop_on_error: false,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert_eq!(result.unwrap(), true, "dry_run should return Ok(true)");
+    assert!(!tgt.exists(), "dry_run must not create the target file");
+    assert!(src.exists(), "dry_run must not remove the source file");
+}
+
+#[test]
+fn process_file_dry_run_move_returns_ok_true_without_moving_file() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("in.txt");
+    std::fs::write(&src, b"data").expect("write src");
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: true,
+        move_files: true,
+        stop_on_error: false,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert_eq!(result.unwrap(), true, "dry_run --move should return Ok(true)");
+    assert!(!tgt.exists(), "dry_run --move must not create the target file");
+    assert!(src.exists(), "dry_run --move must not remove the source file");
+}
+
+#[test]
+fn process_file_copy_success_creates_file_and_keeps_source() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("in.txt");
+    std::fs::write(&src, b"hello").expect("write src");
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: false,
+        move_files: false,
+        stop_on_error: false,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert_eq!(result.unwrap(), true, "successful copy should return Ok(true)");
+    assert!(tgt.exists(), "copy must create the target file");
+    assert!(src.exists(), "copy must not remove the source file");
+}
+
+#[test]
+fn process_file_move_success_creates_target_and_removes_source() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("in.txt");
+    std::fs::write(&src, b"hello").expect("write src");
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: false,
+        move_files: true,
+        stop_on_error: false,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert_eq!(result.unwrap(), true, "successful move should return Ok(true)");
+    assert!(tgt.exists(), "move must create the target file");
+    assert!(!src.exists(), "move must remove the source file");
+}
+
+#[test]
+fn process_file_copy_missing_source_soft_error_returns_ok_false() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("no_such_file.txt"); // intentionally absent
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: false,
+        move_files: false,
+        stop_on_error: false,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert_eq!(
+        result.unwrap(),
+        false,
+        "missing source + stop_on_error=false should return Ok(false)"
+    );
+}
+
+#[test]
+fn process_file_copy_missing_source_hard_error_returns_err() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("no_such_file.txt"); // intentionally absent
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: false,
+        move_files: false,
+        stop_on_error: true,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert!(
+        result.is_err(),
+        "missing source + stop_on_error=true should return Err"
+    );
+}
+
+#[test]
+fn process_file_move_missing_source_soft_error_returns_ok_false() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("no_such_file.txt"); // intentionally absent
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: false,
+        move_files: true,
+        stop_on_error: false,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert_eq!(
+        result.unwrap(),
+        false,
+        "missing source (move) + stop_on_error=false should return Ok(false)"
+    );
+}
+
+#[test]
+fn process_file_move_missing_source_hard_error_returns_err() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let src = dir.path().join("no_such_file.txt"); // intentionally absent
+    let tgt = dir.path().join("out.txt");
+    let opts = ProcessOptions {
+        dry_run: false,
+        move_files: true,
+        stop_on_error: true,
+        show_detail_info: false,
+    };
+    let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+    assert!(
+        result.is_err(),
+        "missing source (move) + stop_on_error=true should return Err"
+    );
+}
+```
+
+Also update the `use super::` line at the top of the test module to import the new items:
+
+```rust
+use super::{check_directory, log_level, process_file, ProcessOptions};
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo test process_file 2>&1 | head -30
+```
+
+Expected: compilation error — `process_file` and `ProcessOptions` not yet defined.
+
+- [ ] **Step 3: Implement `ProcessOptions` and `process_file` in `src/utils.rs`**
+
+Add the following **before** the `#[cfg(test)]` block (i.e., after the closing `}` of `log_build`):
+
+```rust
+/// Options that control per-file processing behaviour, collected from CLI flags.
+pub struct ProcessOptions {
+    pub dry_run: bool,
+    pub move_files: bool,
+    pub stop_on_error: bool,
+    pub show_detail_info: bool,
+}
+
+/// Process a single source file: dry-run preview, copy, or move.
+///
+/// # Returns
+///
+/// - `Ok(true)`  — the file was processed (copied or moved).
+/// - `Ok(false)` — the operation failed but `stop_on_error` is `false`;
+///   the caller should count this as a skipped file and continue.
+/// - `Err(...)`  — the operation failed and `stop_on_error` is `true`;
+///   the caller should propagate the error and halt.
+pub fn process_file(
+    source: &str,
+    target: &std::path::Path,
+    opts: &ProcessOptions,
+) -> anyhow::Result<bool> {
+    let target_display = target.display();
+
+    if opts.dry_run {
+        if opts.move_files {
+            println!("  {source} --> {target_display}");
+        } else {
+            println!("  {source} ==> {target_display}");
+        }
+        return Ok(true);
+    }
+
+    if opts.move_files {
+        log::debug!("Moving {source} to {target_display}");
+        match std::fs::rename(source, target) {
+            Ok(()) => {
+                if opts.show_detail_info {
+                    log::info!("  {source} --> {target_display}");
+                }
+                Ok(true)
+            }
+            Err(err) => {
+                if opts.stop_on_error {
+                    anyhow::bail!(
+                        "Error: {err}. Unable to move {source} to {target_display}. Halting."
+                    );
+                }
+                log::warn!("Unable to move {source} to {target_display}. Continuing.");
+                Ok(false)
+            }
+        }
+    } else {
+        log::debug!("Copying {source} to {target_display}");
+        match std::fs::copy(source, target) {
+            Ok(_) => {
+                if opts.show_detail_info {
+                    log::info!("  {source} ==> {target_display}");
+                }
+                Ok(true)
+            }
+            Err(err) => {
+                if opts.stop_on_error {
+                    anyhow::bail!(
+                        "Error: {err}. Unable to copy {source} to {target_display}. Halting."
+                    );
+                }
+                log::warn!("Unable to copy {source} to {target_display}. Continuing.");
+                Ok(false)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the new unit tests**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo test process_file -- --nocapture 2>&1
+```
+
+Expected: all 8 `process_file_*` tests **PASS**.
+
+- [ ] **Step 5: Run the full test suite to confirm nothing regressed**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo test 2>&1
+```
+
+Expected: all existing tests still **PASS**.
+
+- [ ] **Step 6: Check clippy and formatting**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo fmt && cargo clippy -- -D warnings 2>&1
+```
+
+Expected: zero warnings, zero errors.
+
+---
+
+### Task 2: Refactor `run()` in `main.rs` to call `utils::process_file`
+
+**Files:**
+- Modify: `src/main.rs` (replace the inline if/else chain with `ProcessOptions` + `utils::process_file`)
+
+**Interfaces:**
+- Consumes (from Task 1):
+  ```rust
+  utils::ProcessOptions { dry_run, move_files, stop_on_error, show_detail_info }
+  utils::process_file(source: &str, target: &Path, opts: &ProcessOptions)
+      -> anyhow::Result<bool>
+  ```
+
+---
+
+- [ ] **Step 1: Replace the per-file dispatch block in `run()`**
+
+Replace the complete body of `run()` in `src/main.rs` with:
+
+```rust
+fn run() -> anyhow::Result<()> {
+    // Set up the command line. Ref https://docs.rs/clap for details.
+    let cli_args = cli::build();
+
+    // Set up logging
+    utils::log_build(&cli_args);
+
+    // create a list of the files to gather
+    let sources = cli_args
+        .get_many::<String>("read")
+        .unwrap_or_default()
+        .map(String::as_str);
+    log::debug!("files_to_gather: {sources:?}");
+
+    // Verify that the target exists and that it is a directory
+    let target_dir = cli_args.get_one::<String>("target").expect(
+        "default_value('.') guarantees target is always present — this is a clap bug if None",
+    );
+    log::trace!("target_dir: {target_dir:?}");
+    utils::check_directory(target_dir)?;
+
+    let opts = utils::ProcessOptions {
+        dry_run: cli_args.get_flag("dry-run"),
+        move_files: cli_args.get_flag("move"),
+        stop_on_error: cli_args.get_flag("stop"),
+        show_detail_info: !cli_args.get_flag("detail-off"),
+    };
+    let print_summary = cli_args.get_flag("summary");
+    log::debug!(
+        "move_files: {}, stop_on_error: {}, show_detail_info: {}, dry_run: {}, print_summary: {}",
+        opts.move_files,
+        opts.stop_on_error,
+        opts.show_detail_info,
+        opts.dry_run,
+        print_summary
+    );
+
+    if opts.dry_run {
+        // Write directly to stdout so the banner is never silenced by -q/--quiet.
+        // The quiet flag sets LevelFilter::Off; even log::error! is filtered out.
+        println!("Starting dry-run.");
+    }
+
+    let mut total_file_count: usize = 0;
+    let mut processed_file_count: usize = 0;
+    let mut skipped_file_count: usize = 0;
+
+    // Gather files
+    for source in sources {
+        total_file_count += 1;
+
+        // Paths ending in "/" or ".." have no filename component — treat like any other error.
+        let Some(file_name) = Path::new(source).file_name() else {
+            if opts.stop_on_error {
+                anyhow::bail!("Error: Invalid filename in path: {source}. Halting.");
+            }
+            log::warn!("Invalid filename in path: {source}. Continuing.");
+            skipped_file_count += 1;
+            continue;
+        };
+
+        let new_filename = Path::new(target_dir).join(file_name);
+
+        match utils::process_file(source, &new_filename, &opts)? {
+            true => processed_file_count += 1,
+            false => skipped_file_count += 1,
+        }
+    } // for source
+
+    if print_summary {
+        // Write directly to stdout so the summary is never silenced by -q/--quiet.
+        println!("Total files examined:        {total_file_count:5}");
+        if opts.move_files {
+            println!("Files moved:                 {processed_file_count:5}");
+        } else {
+            println!("Files copied:                {processed_file_count:5}");
+        }
+        println!("Files skipped due to errors: {skipped_file_count:5}");
+    }
+
+    Ok(())
+} // fn run()
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo test 2>&1
+```
+
+Expected: **all tests PASS** — unit tests in `utils.rs` and all integration tests in `tests/cli.rs`.
+
+- [ ] **Step 3: Check clippy and formatting**
+
+```
+cd /Volumes/SSD/Source/Rust/gather
+cargo fmt && cargo clippy -- -D warnings 2>&1
+```
+
+Expected: zero warnings, zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Volumes/SSD/Source/Rust/gather
+/opt/homebrew/bin/git-mit es 2>/dev/null || true
+git add src/utils.rs src/main.rs
+git commit -m "$(cat <<'EOF'
+refactor(main): extract per-file dispatch into process_file (gtr-3aa)
+
+Add ProcessOptions struct and process_file() to utils.rs so the
+dry-run / move / copy logic is independently unit-testable. run()
+now constructs ProcessOptions from CLI flags and delegates per-file
+work to utils::process_file, returning Ok(true/false) or Err for
+the hard-stop case. No behaviour changes; all existing tests pass.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Close the crumb**
+
+```bash
+/Users/evensolberg/.cargo/bin/crumbs close gtr-3aa
+git add .crumbs/extract-per-file-processing-logic-into-a-dedicated-function.md
+git commit -m "$(cat <<'EOF'
+chore(crumbs): close gtr-3aa — process_file extracted
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ Extract `dry_run / move / copy` block → `process_file` in Task 1 + Task 2
+- ✅ `ProcessOptions` struct with all four fields: `dry_run`, `move_files`, `stop_on_error`, `show_detail_info`
+- ✅ Return type `anyhow::Result<bool>`: `Ok(true)` processed, `Ok(false)` skipped, `Err` hard stop
+- ✅ Unit tests for `process_file` in `utils.rs` (8 cases)
+- ✅ `run()` refactored to use `utils::process_file`
+- ✅ All existing integration tests still exercised
+- ✅ Uses anyhow throughout (no `Box<dyn Error>` — assumes gtr-jz8 applied first)
+
+**Placeholder scan:** No TBDs, no vague steps, all code blocks are complete.
+
+**Type consistency:** `ProcessOptions` defined in Task 1 Step 3 matches its use in Task 2 Step 1 field-for-field. `process_file` signature is identical in tests (Task 1 Step 1), implementation (Task 1 Step 3), and call-site (Task 2 Step 1). All error returns use `anyhow::bail!` consistently.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,14 +26,23 @@ fn run() -> anyhow::Result<()> {
     log::trace!("target_dir: {target_dir:?}");
     utils::check_directory(target_dir)?;
 
-    let move_files = cli_args.get_flag("move");
-    let stop_on_error = cli_args.get_flag("stop");
-    let show_detail_info = !cli_args.get_flag("detail-off");
-    let dry_run = cli_args.get_flag("dry-run");
+    let opts = utils::ProcessOptions {
+        dry_run: cli_args.get_flag("dry-run"),
+        move_files: cli_args.get_flag("move"),
+        stop_on_error: cli_args.get_flag("stop"),
+        show_detail_info: !cli_args.get_flag("detail-off"),
+    };
     let print_summary = cli_args.get_flag("summary");
-    log::debug!("move_files: {move_files}, stop_on_error: {stop_on_error}, show_detail_info: {show_detail_info}, dry_run: {dry_run}, print_summary: {print_summary}");
+    log::debug!(
+        "move_files: {}, stop_on_error: {}, show_detail_info: {}, dry_run: {}, print_summary: {}",
+        opts.move_files,
+        opts.stop_on_error,
+        opts.show_detail_info,
+        opts.dry_run,
+        print_summary
+    );
 
-    if dry_run {
+    if opts.dry_run {
         // Write directly to stdout so the banner is never silenced by -q/--quiet.
         // The quiet flag sets LevelFilter::Off; even log::error! is filtered out.
         println!("Starting dry-run.");
@@ -49,7 +58,7 @@ fn run() -> anyhow::Result<()> {
 
         // Paths ending in "/" or ".." have no filename component — treat like any other error.
         let Some(file_name) = Path::new(source).file_name() else {
-            if stop_on_error {
+            if opts.stop_on_error {
                 anyhow::bail!("Error: Invalid filename in path: {source}. Halting.");
             }
             log::warn!("Invalid filename in path: {source}. Continuing.");
@@ -58,56 +67,11 @@ fn run() -> anyhow::Result<()> {
         };
 
         let new_filename = Path::new(target_dir).join(file_name);
-        let target = new_filename.display();
 
-        if dry_run {
-            // Write directly to stdout so previews are never silenced by -q/--quiet.
-            // Same reasoning as the banner above and the print_summary block below.
-            if move_files {
-                println!("  {source} --> {target}");
-            } else {
-                println!("  {source} ==> {target}");
-            }
-            processed_file_count += 1;
-        } else if move_files {
-            log::debug!("Moving {source} to {target}");
-            match std::fs::rename(source, &new_filename) {
-                Ok(()) => {
-                    if show_detail_info {
-                        log::info!("  {source} --> {target}");
-                    }
-                    processed_file_count += 1;
-                }
-                Err(err) => {
-                    if stop_on_error {
-                        anyhow::bail!(
-                            "Error: {err}. Unable to move {source} to {target}. Halting."
-                        );
-                    }
-                    log::warn!("Unable to move {source} to {target}. Continuing.");
-                    skipped_file_count += 1;
-                }
-            }
-        } else {
-            log::debug!("Copying {source} to {target}");
-            match std::fs::copy(source, &new_filename) {
-                Ok(_) => {
-                    if show_detail_info {
-                        log::info!("  {source} ==> {target}");
-                    }
-                    processed_file_count += 1;
-                }
-                Err(err) => {
-                    if stop_on_error {
-                        anyhow::bail!(
-                            "Error: {err}. Unable to copy {source} to {target}. Halting."
-                        );
-                    }
-                    log::warn!("Unable to copy {source} to {target}. Continuing.");
-                    skipped_file_count += 1;
-                }
-            }
-        } // if dry_run
+        match utils::process_file(source, &new_filename, &opts)? {
+            true => processed_file_count += 1,
+            false => skipped_file_count += 1,
+        }
     } // for source
 
     if print_summary {
@@ -115,7 +79,7 @@ fn run() -> anyhow::Result<()> {
         // The quiet flag sets LevelFilter::Off; if we used log::info! or log::error!
         // here they would be filtered out when the two flags are combined.
         println!("Total files examined:        {total_file_count:5}");
-        if move_files {
+        if opts.move_files {
             println!("Files moved:                 {processed_file_count:5}");
         } else {
             println!("Files copied:                {processed_file_count:5}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,11 @@ fn run() -> anyhow::Result<()> {
     };
     let print_summary = cli_args.get_flag("summary");
     log::debug!(
-        "move_files: {}, stop_on_error: {}, show_detail_info: {}, dry_run: {}, print_summary: {}",
+        "dry_run: {}, move_files: {}, stop_on_error: {}, show_detail_info: {}, print_summary: {}",
+        opts.dry_run,
         opts.move_files,
         opts.stop_on_error,
         opts.show_detail_info,
-        opts.dry_run,
         print_summary
     );
 
@@ -59,7 +59,7 @@ fn run() -> anyhow::Result<()> {
         // Paths ending in "/" or ".." have no filename component — treat like any other error.
         let Some(file_name) = Path::new(source).file_name() else {
             if opts.stop_on_error {
-                anyhow::bail!("Error: Invalid filename in path: {source}. Halting.");
+                anyhow::bail!("Invalid filename in path: {source}. Halting.");
             }
             log::warn!("Invalid filename in path: {source}. Continuing.");
             skipped_file_count += 1;
@@ -68,9 +68,10 @@ fn run() -> anyhow::Result<()> {
 
         let new_filename = Path::new(target_dir).join(file_name);
 
-        match utils::process_file(source, &new_filename, &opts)? {
-            true => processed_file_count += 1,
-            false => skipped_file_count += 1,
+        if utils::process_file(source, &new_filename, &opts)? {
+            processed_file_count += 1;
+        } else {
+            skipped_file_count += 1;
         }
     } // for source
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
 mod cli;
 mod utils;
 
-use std::error::Error;
 use std::path::Path;
-
-// Logging
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// This is where the magic happens.
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> anyhow::Result<()> {
     // Set up the command line. Ref https://docs.rs/clap for details.
     let cli_args = cli::build();
 
@@ -53,7 +50,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         // Paths ending in "/" or ".." have no filename component — treat like any other error.
         let Some(file_name) = Path::new(source).file_name() else {
             if stop_on_error {
-                return Err(format!("Error: Invalid filename in path: {source}. Halting.").into());
+                anyhow::bail!("Error: Invalid filename in path: {source}. Halting.");
             }
             log::warn!("Invalid filename in path: {source}. Continuing.");
             skipped_file_count += 1;
@@ -83,10 +80,9 @@ fn run() -> Result<(), Box<dyn Error>> {
                 }
                 Err(err) => {
                     if stop_on_error {
-                        return Err(format!(
+                        anyhow::bail!(
                             "Error: {err}. Unable to move {source} to {target}. Halting."
-                        )
-                        .into());
+                        );
                     }
                     log::warn!("Unable to move {source} to {target}. Continuing.");
                     skipped_file_count += 1;
@@ -103,17 +99,16 @@ fn run() -> Result<(), Box<dyn Error>> {
                 }
                 Err(err) => {
                     if stop_on_error {
-                        return Err(format!(
+                        anyhow::bail!(
                             "Error: {err}. Unable to copy {source} to {target}. Halting."
-                        )
-                        .into());
+                        );
                     }
                     log::warn!("Unable to copy {source} to {target}. Continuing.");
                     skipped_file_count += 1;
                 }
             }
         } // if dry_run
-    } // for filename
+    } // for source
 
     if print_summary {
         // Write directly to stdout so the summary is never silenced by -q/--quiet.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ pub fn check_directory(target: &str) -> anyhow::Result<()> {
     let metadata =
         std::fs::metadata(target).with_context(|| format!("Target directory '{target}'"))?;
     if !metadata.is_dir() {
-        anyhow::bail!("Specified target is not a directory. Unable to proceed.");
+        anyhow::bail!("Target '{target}' is not a directory. Unable to proceed.");
     }
     log::debug!("Specified target is a directory. Proceeding.");
 
@@ -55,6 +55,7 @@ pub fn log_build(cli_args: &clap::ArgMatches) {
 }
 
 /// Options that control per-file processing behaviour, collected from CLI flags.
+#[derive(Debug)]
 pub struct ProcessOptions {
     pub dry_run: bool,
     pub move_files: bool,
@@ -98,9 +99,7 @@ pub fn process_file(
             }
             Err(err) => {
                 if opts.stop_on_error {
-                    anyhow::bail!(
-                        "Error: {err}. Unable to move {source} to {target_display}. Halting."
-                    );
+                    anyhow::bail!("{err}. Unable to move {source} to {target_display}. Halting.");
                 }
                 log::warn!("Unable to move {source} to {target_display}. Continuing.");
                 Ok(false)
@@ -117,9 +116,7 @@ pub fn process_file(
             }
             Err(err) => {
                 if opts.stop_on_error {
-                    anyhow::bail!(
-                        "Error: {err}. Unable to copy {source} to {target_display}. Halting."
-                    );
+                    anyhow::bail!("{err}. Unable to copy {source} to {target_display}. Halting.");
                 }
                 log::warn!("Unable to copy {source} to {target_display}. Continuing.");
                 Ok(false)
@@ -215,7 +212,7 @@ mod tests {
             show_detail_info: false,
         };
         let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
-        assert_eq!(result.unwrap(), true, "dry_run should return Ok(true)");
+        assert!(result.unwrap(), "dry_run should return Ok(true)");
         assert!(!tgt.exists(), "dry_run must not create the target file");
         assert!(src.exists(), "dry_run must not remove the source file");
     }
@@ -233,11 +230,7 @@ mod tests {
             show_detail_info: false,
         };
         let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
-        assert_eq!(
-            result.unwrap(),
-            true,
-            "dry_run --move should return Ok(true)"
-        );
+        assert!(result.unwrap(), "dry_run --move should return Ok(true)");
         assert!(
             !tgt.exists(),
             "dry_run --move must not create the target file"
@@ -261,11 +254,7 @@ mod tests {
             show_detail_info: false,
         };
         let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
-        assert_eq!(
-            result.unwrap(),
-            true,
-            "successful copy should return Ok(true)"
-        );
+        assert!(result.unwrap(), "successful copy should return Ok(true)");
         assert!(tgt.exists(), "copy must create the target file");
         assert!(src.exists(), "copy must not remove the source file");
     }
@@ -283,11 +272,7 @@ mod tests {
             show_detail_info: false,
         };
         let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
-        assert_eq!(
-            result.unwrap(),
-            true,
-            "successful move should return Ok(true)"
-        );
+        assert!(result.unwrap(), "successful move should return Ok(true)");
         assert!(tgt.exists(), "move must create the target file");
         assert!(!src.exists(), "move must remove the source file");
     }
@@ -304,9 +289,8 @@ mod tests {
             show_detail_info: false,
         };
         let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "missing source + stop_on_error=false should return Ok(false)"
         );
     }
@@ -341,9 +325,8 @@ mod tests {
             show_detail_info: false,
         };
         let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
-        assert_eq!(
-            result.unwrap(),
-            false,
+        assert!(
+            !result.unwrap(),
             "missing source (move) + stop_on_error=false should return Ok(false)"
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,9 +54,83 @@ pub fn log_build(cli_args: &clap::ArgMatches) {
         .init();
 }
 
+/// Options that control per-file processing behaviour, collected from CLI flags.
+pub struct ProcessOptions {
+    pub dry_run: bool,
+    pub move_files: bool,
+    pub stop_on_error: bool,
+    pub show_detail_info: bool,
+}
+
+/// Process a single source file: dry-run preview, copy, or move.
+///
+/// # Returns
+///
+/// - `Ok(true)`  — the file was processed (copied or moved).
+/// - `Ok(false)` — the operation failed but `stop_on_error` is `false`;
+///   the caller should count this as a skipped file and continue.
+/// - `Err(...)`  — the operation failed and `stop_on_error` is `true`;
+///   the caller should propagate the error and halt.
+pub fn process_file(
+    source: &str,
+    target: &std::path::Path,
+    opts: &ProcessOptions,
+) -> anyhow::Result<bool> {
+    let target_display = target.display();
+
+    if opts.dry_run {
+        if opts.move_files {
+            println!("  {source} --> {target_display}");
+        } else {
+            println!("  {source} ==> {target_display}");
+        }
+        return Ok(true);
+    }
+
+    if opts.move_files {
+        log::debug!("Moving {source} to {target_display}");
+        match std::fs::rename(source, target) {
+            Ok(()) => {
+                if opts.show_detail_info {
+                    log::info!("  {source} --> {target_display}");
+                }
+                Ok(true)
+            }
+            Err(err) => {
+                if opts.stop_on_error {
+                    anyhow::bail!(
+                        "Error: {err}. Unable to move {source} to {target_display}. Halting."
+                    );
+                }
+                log::warn!("Unable to move {source} to {target_display}. Continuing.");
+                Ok(false)
+            }
+        }
+    } else {
+        log::debug!("Copying {source} to {target_display}");
+        match std::fs::copy(source, target) {
+            Ok(_) => {
+                if opts.show_detail_info {
+                    log::info!("  {source} ==> {target_display}");
+                }
+                Ok(true)
+            }
+            Err(err) => {
+                if opts.stop_on_error {
+                    anyhow::bail!(
+                        "Error: {err}. Unable to copy {source} to {target_display}. Halting."
+                    );
+                }
+                log::warn!("Unable to copy {source} to {target_display}. Continuing.");
+                Ok(false)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{check_directory, log_level};
+    use super::{check_directory, log_level, process_file, ProcessOptions};
     use log::LevelFilter;
 
     // ---------------------------------------------------------------------------
@@ -122,5 +196,173 @@ mod tests {
     fn log_level_three_debug_flags_also_returns_trace() {
         // Confirms the wildcard arm covers all values above 1, not just exactly 2.
         assert_eq!(log_level(false, 3), LevelFilter::Trace);
+    }
+
+    // ---------------------------------------------------------------------------
+    // process_file
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn process_file_dry_run_copy_returns_ok_true_without_creating_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("in.txt");
+        std::fs::write(&src, b"data").expect("write src");
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: true,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert_eq!(result.unwrap(), true, "dry_run should return Ok(true)");
+        assert!(!tgt.exists(), "dry_run must not create the target file");
+        assert!(src.exists(), "dry_run must not remove the source file");
+    }
+
+    #[test]
+    fn process_file_dry_run_move_returns_ok_true_without_moving_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("in.txt");
+        std::fs::write(&src, b"data").expect("write src");
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: true,
+            move_files: true,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert_eq!(
+            result.unwrap(),
+            true,
+            "dry_run --move should return Ok(true)"
+        );
+        assert!(
+            !tgt.exists(),
+            "dry_run --move must not create the target file"
+        );
+        assert!(
+            src.exists(),
+            "dry_run --move must not remove the source file"
+        );
+    }
+
+    #[test]
+    fn process_file_copy_success_creates_file_and_keeps_source() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("in.txt");
+        std::fs::write(&src, b"hello").expect("write src");
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert_eq!(
+            result.unwrap(),
+            true,
+            "successful copy should return Ok(true)"
+        );
+        assert!(tgt.exists(), "copy must create the target file");
+        assert!(src.exists(), "copy must not remove the source file");
+    }
+
+    #[test]
+    fn process_file_move_success_creates_target_and_removes_source() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("in.txt");
+        std::fs::write(&src, b"hello").expect("write src");
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: true,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert_eq!(
+            result.unwrap(),
+            true,
+            "successful move should return Ok(true)"
+        );
+        assert!(tgt.exists(), "move must create the target file");
+        assert!(!src.exists(), "move must remove the source file");
+    }
+
+    #[test]
+    fn process_file_copy_missing_source_soft_error_returns_ok_false() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("no_such_file.txt"); // intentionally absent
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert_eq!(
+            result.unwrap(),
+            false,
+            "missing source + stop_on_error=false should return Ok(false)"
+        );
+    }
+
+    #[test]
+    fn process_file_copy_missing_source_hard_error_returns_err() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("no_such_file.txt"); // intentionally absent
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert!(
+            result.is_err(),
+            "missing source + stop_on_error=true should return Err"
+        );
+    }
+
+    #[test]
+    fn process_file_move_missing_source_soft_error_returns_ok_false() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("no_such_file.txt"); // intentionally absent
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: true,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert_eq!(
+            result.unwrap(),
+            false,
+            "missing source (move) + stop_on_error=false should return Ok(false)"
+        );
+    }
+
+    #[test]
+    fn process_file_move_missing_source_hard_error_returns_err() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("no_such_file.txt"); // intentionally absent
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: true,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert!(
+            result.is_err(),
+            "missing source (move) + stop_on_error=true should return Err"
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,49 +78,37 @@ pub fn process_file(
     opts: &ProcessOptions,
 ) -> anyhow::Result<bool> {
     let target_display = target.display();
+    let (verb, past, arrow) = if opts.move_files {
+        ("Moving", "move", "-->")
+    } else {
+        ("Copying", "copy", "==>")
+    };
 
     if opts.dry_run {
-        if opts.move_files {
-            println!("  {source} --> {target_display}");
-        } else {
-            println!("  {source} ==> {target_display}");
-        }
+        println!("  {source} {arrow} {target_display}");
         return Ok(true);
     }
 
-    if opts.move_files {
-        log::debug!("Moving {source} to {target_display}");
-        match std::fs::rename(source, target) {
-            Ok(()) => {
-                if opts.show_detail_info {
-                    log::info!("  {source} --> {target_display}");
-                }
-                Ok(true)
-            }
-            Err(err) => {
-                if opts.stop_on_error {
-                    anyhow::bail!("{err}. Unable to move {source} to {target_display}. Halting.");
-                }
-                log::warn!("Unable to move {source} to {target_display}. Continuing.");
-                Ok(false)
-            }
-        }
+    log::debug!("{verb} {source} to {target_display}");
+    let result: Result<(), std::io::Error> = if opts.move_files {
+        std::fs::rename(source, target)
     } else {
-        log::debug!("Copying {source} to {target_display}");
-        match std::fs::copy(source, target) {
-            Ok(_) => {
-                if opts.show_detail_info {
-                    log::info!("  {source} ==> {target_display}");
-                }
-                Ok(true)
+        std::fs::copy(source, target).map(|_| ())
+    };
+
+    match result {
+        Ok(()) => {
+            if opts.show_detail_info {
+                log::info!("  {source} {arrow} {target_display}");
             }
-            Err(err) => {
-                if opts.stop_on_error {
-                    anyhow::bail!("{err}. Unable to copy {source} to {target_display}. Halting.");
-                }
-                log::warn!("Unable to copy {source} to {target_display}. Continuing.");
-                Ok(false)
+            Ok(true)
+        }
+        Err(err) => {
+            if opts.stop_on_error {
+                anyhow::bail!("{err}. Unable to {past} {source} to {target_display}. Halting.");
             }
+            log::warn!("Unable to {past} {source} to {target_display}. Continuing.");
+            Ok(false)
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use env_logger::{Builder, Target};
 use log::LevelFilter;
 
@@ -9,11 +10,13 @@ use log::LevelFilter;
 ///
 /// # Returns
 ///
-/// - `Result<(), Box<dyn std::error::Error>>` - returns an empty `Ok()` if it is a directory, or an error if not.
-pub fn check_directory(target: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let metadata = std::fs::metadata(target).map_err(|e| format!("Target: {e}"))?;
+/// - `anyhow::Result<()>` - returns an empty `Ok()` if it is a directory, or an
+///   error (with the target path embedded) if not.
+pub fn check_directory(target: &str) -> anyhow::Result<()> {
+    let metadata =
+        std::fs::metadata(target).with_context(|| format!("Target directory '{target}'"))?;
     if !metadata.is_dir() {
-        return Err("Specified target is not a directory. Unable to proceed.".into());
+        anyhow::bail!("Specified target is not a directory. Unable to proceed.");
     }
     log::debug!("Specified target is a directory. Proceeding.");
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,7 +78,7 @@ pub fn process_file(
     opts: &ProcessOptions,
 ) -> anyhow::Result<bool> {
     let target_display = target.display();
-    let (verb, past, arrow) = if opts.move_files {
+    let (verb, op, arrow) = if opts.move_files {
         ("Moving", "move", "-->")
     } else {
         ("Copying", "copy", "==>")
@@ -105,9 +105,10 @@ pub fn process_file(
         }
         Err(err) => {
             if opts.stop_on_error {
-                anyhow::bail!("{err}. Unable to {past} {source} to {target_display}. Halting.");
+                return Err(err)
+                    .with_context(|| format!("Unable to {op} '{source}' to '{target_display}'"));
             }
-            log::warn!("Unable to {past} {source} to {target_display}. Continuing.");
+            log::warn!("Unable to {op} {source} to {target_display}. Continuing.");
             Ok(false)
         }
     }


### PR DESCRIPTION
## Summary

- **gtr-jz8** — Replace `Box<dyn Error>` with `anyhow::Error` throughout. Use `.with_context()` in `check_directory` to embed the target path in OS errors; use `anyhow::bail!` at all error sites. Strips the redundant `"Error: "` prefix so `eprintln!("{err}")` in `main()` never double-labels output.

- **gtr-3aa** — Extract the per-file `dry_run / move / copy` dispatch block from `run()` into `utils::process_file(source, target, opts) -> anyhow::Result<bool>`. Adds `#[derive(Debug)] ProcessOptions` to carry the four CLI flags. Adds 8 unit tests covering all branches (dry-run copy/move, successful copy/move, soft-error and hard-error for both operations). Unifies the move/copy arms into a single `match` with pre-computed `(verb, past, arrow)`, reducing `process_file` from ~45 lines to ~28.

## Test plan

- [ ] `cargo test` — 32 tests pass (20 unit, 12 integration)
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo fmt` — no drift
- [ ] Integration tests exercise all CLI flag combinations including `-q -p`, `-n -q`, `--stop-on-error`, and `--move`

🤖 Generated with [Claude Code](https://claude.com/claude-code)