### PR TITLE
feat: add pre-flight source-file existence check (gtr-wek)

### DIFF
--- a/.crumbs/add-file-existence-pre-validation-before-the-processing-loop.md
+++ b/.crumbs/add-file-existence-pre-validation-before-the-processing-loop.md
@@ -1,14 +1,14 @@
 ---
 id: gtr-wek
 title: Add file existence pre-validation before the processing loop
-status: open
+status: closed
 type: feature
 priority: 3
 tags:
 - ux
 - validation
 created: 2026-06-08
-updated: 2026-06-08
+updated: 2026-07-03
 phase: ''
 ---
 
@@ -19,3 +19,5 @@ errors surface mid-run after some files may already have been moved/copied.
 Add a pre-flight pass: check all source paths with Path::exists() upfront and either
 abort early (if stop_on_error) or print all missing paths before doing any work.
 This gives users a complete error picture before any destructive moves begin.
+
+[start] 2026-07-03 16:16:54

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,10 @@ fn run() -> anyhow::Result<()> {
         println!("Starting dry-run.");
     }
 
-    // Pre-flight: in hard-error, non-dry-run mode abort if any source path is
-    // absent, inaccessible, or not a regular file — before touching any files.
+    // Pre-flight: abort if any source path is absent, inaccessible, or not a
+    // regular file before touching any files.  Dry-run intentionally skips
+    // this — dry-run is a best-effort preview ("what would happen?") and
+    // should show per-file notices rather than aborting, even with --stop.
     if opts.stop_on_error && !opts.dry_run {
         utils::validate_sources(&sources)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,9 @@ fn run() -> anyhow::Result<()> {
         // (Component::ParentDir, e.g. "foo/..") or the path is the root "/"
         // (Component::RootDir) — neither has a usable target filename.
         // In soft-error mode validate_sources is a no-op so this guard is the
-        // sole protection; in stop_on_error mode validate_sources catches these
-        // paths first (as "not a regular file"), making the bail! branch a
-        // defensive fallback.
+        // sole protection; in stop_on_error mode validate_sources will have
+        // already rejected such paths (e.g. as not found, not a regular file,
+        // or inaccessible), making the bail! branch a defensive fallback.
         let Some(file_name) = Path::new(source).file_name() else {
             if opts.stop_on_error {
                 anyhow::bail!("Invalid filename in path: {source}. Halting.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,12 @@ fn run() -> anyhow::Result<()> {
     for source in sources.iter().copied() {
         total_file_count += 1;
 
-        // Paths ending in "/" or ".." have no filename component — treat like
-        // any other error.  In soft-error mode validate_sources is a no-op so
-        // this guard is the sole protection; in stop_on_error mode
-        // validate_sources catches these paths first (as "not a regular file"),
-        // making the bail! branch a defensive fallback.
+        // Paths whose last component is ".." (e.g. "foo/..") or that are the
+        // root ("/") have no filename component — treat like any other error.
+        // In soft-error mode validate_sources is a no-op so this guard is the
+        // sole protection; in stop_on_error mode validate_sources catches these
+        // paths first (as "not a regular file"), making the bail! branch a
+        // defensive fallback.
         let Some(file_name) = Path::new(source).file_name() else {
             if opts.stop_on_error {
                 anyhow::bail!("Invalid filename in path: {source}. Halting.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn run() -> anyhow::Result<()> {
 
     // Pre-flight existence check: only useful when the user asked for a hard stop
     // on errors and this is not a dry-run.  In soft-error mode or dry-run the
-    // function is a no-op, so skip the Path::exists() pass over every source.
+    // function is a no-op, so skip the Path::try_exists() pass over every source.
     if opts.stop_on_error && !opts.dry_run {
         utils::validate_sources(&sources, &opts)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,12 +50,10 @@ fn run() -> anyhow::Result<()> {
         println!("Starting dry-run.");
     }
 
-    // Pre-flight existence check: only useful when the user asked for a hard stop
-    // on errors and this is not a dry-run.  In soft-error mode or dry-run the
-    // function is a no-op, so skip the Path::try_exists() pass over every source.
-    if opts.stop_on_error && !opts.dry_run {
-        utils::validate_sources(&sources, &opts)?;
-    }
+    // Pre-flight existence check: validate_sources returns Ok(()) immediately in
+    // soft-error mode or dry-run; calling it unconditionally keeps the activation
+    // condition in one place (inside the function) rather than duplicated here.
+    utils::validate_sources(&sources, &opts)?;
 
     let mut total_file_count: usize = 0;
     let mut processed_file_count: usize = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,12 @@ fn run() -> anyhow::Result<()> {
         println!("Starting dry-run.");
     }
 
-    // Pre-flight: check all source paths exist before doing any file operations.
-    // Reports every missing path upfront so the user sees the full error picture
-    // before any files are moved or copied.
-    utils::validate_sources(&sources, &opts)?;
+    // Pre-flight existence check: only useful when the user asked for a hard stop
+    // on errors and this is not a dry-run.  In soft-error mode or dry-run the
+    // function is a no-op, so skip the Path::exists() pass over every source.
+    if opts.stop_on_error && !opts.dry_run {
+        utils::validate_sources(&sources, &opts)?;
+    }
 
     let mut total_file_count: usize = 0;
     let mut processed_file_count: usize = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,11 @@ fn run() -> anyhow::Result<()> {
         println!("Starting dry-run.");
     }
 
-    // Pre-flight existence check: validate_sources returns Ok(()) immediately in
-    // soft-error mode or dry-run; calling it unconditionally keeps the activation
-    // condition in one place (inside the function) rather than duplicated here.
-    utils::validate_sources(&sources, &opts)?;
+    // Pre-flight: in hard-error, non-dry-run mode abort if any source path is
+    // absent, inaccessible, or not a regular file — before touching any files.
+    if opts.stop_on_error && !opts.dry_run {
+        utils::validate_sources(&sources)?;
+    }
 
     let mut total_file_count: usize = 0;
     let mut processed_file_count: usize = 0;
@@ -66,10 +67,10 @@ fn run() -> anyhow::Result<()> {
         // Path::file_name() returns None when the last path component is ".."
         // (Component::ParentDir, e.g. "foo/..") or the path is the root "/"
         // (Component::RootDir) — neither has a usable target filename.
-        // In soft-error mode validate_sources is a no-op so this guard is the
-        // sole protection; in stop_on_error mode validate_sources will have
-        // already rejected such paths (e.g. as not found, not a regular file,
-        // or inaccessible), making the bail! branch a defensive fallback.
+        // In soft-error mode validate_sources is not called, so this guard is
+        // the sole protection; in stop_on_error mode validate_sources will
+        // have already rejected such paths (e.g. as not found, not a regular
+        // file, or inaccessible), making the bail! branch a defensive fallback.
         let Some(file_name) = Path::new(source).file_name() else {
             if opts.stop_on_error {
                 anyhow::bail!("Invalid filename in path: {source}. Halting.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,9 @@ fn run() -> anyhow::Result<()> {
     for source in sources.iter().copied() {
         total_file_count += 1;
 
-        // Paths whose last component is ".." (e.g. "foo/..") or that are the
-        // root ("/") have no filename component — treat like any other error.
+        // Path::file_name() returns None when the last path component is ".."
+        // (Component::ParentDir, e.g. "foo/..") or the path is the root "/"
+        // (Component::RootDir) — neither has a usable target filename.
         // In soft-error mode validate_sources is a no-op so this guard is the
         // sole protection; in stop_on_error mode validate_sources catches these
         // paths first (as "not a regular file"), making the bail! branch a

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,13 @@ fn run() -> anyhow::Result<()> {
     // Set up logging
     utils::log_build(&cli_args);
 
-    // create a list of the files to gather
-    let sources = cli_args
+    // Collect source paths into a Vec so we can run the pre-flight existence
+    // check over the whole list before touching any files.
+    let sources: Vec<&str> = cli_args
         .get_many::<String>("read")
         .unwrap_or_default()
-        .map(String::as_str);
+        .map(String::as_str)
+        .collect();
     log::debug!("files_to_gather: {sources:?}");
 
     // Verify that the target exists and that it is a directory
@@ -48,12 +50,17 @@ fn run() -> anyhow::Result<()> {
         println!("Starting dry-run.");
     }
 
+    // Pre-flight: check all source paths exist before doing any file operations.
+    // Reports every missing path upfront so the user sees the full error picture
+    // before any files are moved or copied.
+    utils::validate_sources(&sources, &opts)?;
+
     let mut total_file_count: usize = 0;
     let mut processed_file_count: usize = 0;
     let mut skipped_file_count: usize = 0;
 
     // Gather files
-    for source in sources {
+    for source in &sources {
         total_file_count += 1;
 
         // Paths ending in "/" or ".." have no filename component — treat like any other error.

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn run() -> anyhow::Result<()> {
     let mut skipped_file_count: usize = 0;
 
     // Gather files
-    for source in &sources {
+    for source in sources.iter().copied() {
         total_file_count += 1;
 
         // Paths ending in "/" or ".." have no filename component — treat like any other error.

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,11 @@ fn run() -> anyhow::Result<()> {
     for source in sources.iter().copied() {
         total_file_count += 1;
 
-        // Paths ending in "/" or ".." have no filename component — treat like any other error.
+        // Paths ending in "/" or ".." have no filename component — treat like
+        // any other error.  In soft-error mode validate_sources is a no-op so
+        // this guard is the sole protection; in stop_on_error mode
+        // validate_sources catches these paths first (as "not a regular file"),
+        // making the bail! branch a defensive fallback.
         let Some(file_name) = Path::new(source).file_name() else {
             if opts.stop_on_error {
                 anyhow::bail!("Invalid filename in path: {source}. Halting.");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -453,15 +453,17 @@ mod tests {
             f1.to_str().expect("utf-8"),
             f2.to_str().expect("utf-8"),
         ];
+        // Use stop_on_error=true so the function actually performs the
+        // try_exists() scan rather than returning early at the guard.
         let opts = ProcessOptions {
             dry_run: false,
             move_files: false,
-            stop_on_error: false,
+            stop_on_error: true,
             show_detail_info: false,
         };
         assert!(
             validate_sources(&sources, &opts).is_ok(),
-            "all paths exist — should return Ok"
+            "all paths exist — should return Ok even with stop_on_error=true"
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,64 +63,76 @@ pub struct ProcessOptions {
     pub show_detail_info: bool,
 }
 
-/// Pre-flight existence check: report all missing source paths before processing.
+/// Pre-flight existence check: verify all source paths can be processed.
 ///
-/// Iterates over `sources` and collects every path that does not exist on disk.
-/// When `stop_on_error` is `true` and `dry_run` is `false`, returns an error
-/// listing all missing paths so the user sees the complete picture in one
-/// message before any files are moved or copied.  In all other cases the
-/// function returns `Ok(())` without emitting any output; per-file feedback for
-/// missing sources is handled by `process_file` when the copy or move fails.
+/// Iterates over `sources` and checks each path for: (1) a valid filename
+/// component, (2) filesystem existence via `try_exists()`.  When
+/// `stop_on_error` is `true` and `dry_run` is `false`, returns an error
+/// listing every problematic path so the user sees the complete picture in
+/// one message before any files are moved or copied.  In all other cases the
+/// function returns `Ok(())` without emitting any output; per-file feedback
+/// is handled by `process_file`.
+///
+/// OS-level errors (e.g. permission denied) are collected into the same batch
+/// message rather than causing an immediate return, so all unreachable paths
+/// are reported together.
 ///
 /// # Returns
 ///
-/// - `Ok(())` when all paths exist, or when the caller has opted out of hard
-///   errors (`stop_on_error = false`, or `dry_run = true`).
-/// - `Err(...)` when one or more paths are absent and `stop_on_error` is `true`
-///   and `dry_run` is `false`.
+/// - `Ok(())` when all paths are valid and exist, or when the caller has opted
+///   out of hard errors (`stop_on_error = false`, or `dry_run = true`).
+/// - `Err(...)` when one or more paths are problematic and `stop_on_error` is
+///   `true` and `dry_run` is `false`.
 pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Result<()> {
-    // Only meaningful in hard-error, non-dry-run mode.  The caller guards this,
-    // but the check is kept here too so the function is self-contained for tests.
+    // Only meaningful in hard-error, non-dry-run mode; the function is
+    // self-contained so tests can call it directly with any option combination.
     if !opts.stop_on_error || opts.dry_run {
         return Ok(());
     }
 
-    // Use try_exists() rather than exists() so that OS errors such as "permission
-    // denied" surface as immediate hard errors instead of being silently treated
-    // as "not found".  exists() returns false for *any* metadata failure; only
-    // Ok(false) from try_exists() means the file is genuinely absent.
+    // Collect every problematic path so the user sees the full picture before
+    // any files are moved or copied.  OS errors are included inline rather than
+    // causing an immediate return — the message still lists all other issues.
     //
     // Note: a TOCTOU race exists between this check and the actual fs::copy /
     // fs::rename in process_file.  A file deleted between the two points will
     // produce a false-clean pre-flight followed by a mid-run copy error.  This
     // is inherent in any check-then-act design and is acceptable for the
     // single-user interactive use case this tool targets.
-    let mut missing: Vec<&str> = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
     for &s in sources {
+        // Paths with no filename component (e.g. ending in '/' or '..') are
+        // invalid regardless of existence; report them before stat'ing.
+        if std::path::Path::new(s).file_name().is_none() {
+            problems.push(format!("{s} (no filename component)"));
+            continue;
+        }
+        // Use try_exists() so that Ok(false) means "genuinely absent" while
+        // Err means "OS error" — exists() would return false for both cases,
+        // losing the distinction.
         match std::path::Path::new(s).try_exists() {
-            Ok(true) => {}  // file exists — nothing to do
-            Ok(false) => missing.push(s),
+            Ok(true) => {}  // file accessible — nothing to do
+            Ok(false) => problems.push(s.to_string()),
             Err(err) => {
-                // An OS-level error while probing existence (e.g. permission
-                // denied) will almost certainly prevent the copy/move from
-                // succeeding too; surface it immediately with context.
-                return Err(err)
-                    .with_context(|| format!("Unable to access source file '{s}'"));
+                // OS-level error (e.g. permission denied): add to the problem
+                // list rather than returning early so every unreachable path
+                // appears in one batch message.
+                problems.push(format!("{s} ({err})"));
             }
         }
     }
 
-    if missing.is_empty() {
+    if problems.is_empty() {
         return Ok(());
     }
 
-    // Include every missing path in the error message so it appears on stderr
-    // via the `eprintln!` in main(), giving the user the full picture before any
-    // files are moved or copied.
+    // Include every problem path in the error message so it appears on stderr
+    // via the `eprintln!` in main(), giving the user the full picture before
+    // any files are moved or copied.
     anyhow::bail!(
         "{} source file(s) not found:\n  {}\nHalting.",
-        missing.len(),
-        missing.join("\n  ")
+        problems.len(),
+        problems.join("\n  ")
     );
 }
 
@@ -146,26 +158,26 @@ pub fn process_file(
     };
 
     if opts.dry_run {
-        // Best-effort guard for the dry-run preview.  try_exists() checks
-        // whether the filesystem can retrieve the entry's metadata (a stat
-        // call).  Ok(false) means the entry is absent; Err means even the
-        // stat failed (e.g. search permission denied on the parent directory).
-        // Note: try_exists() returning Ok(true) does NOT guarantee the file is
-        // readable — a file that passes here could still fail to be copied if
-        // read permission is denied.  Dry-run is inherently best-effort; the
-        // real copy will surface any such permission error.  Use println! so
-        // the notice is always visible, matching the arrow lines which also
-        // bypass the logger (-q does not suppress them).
-        match std::path::Path::new(source).try_exists() {
-            Ok(false) => {
+        // Use metadata() to check existence, accessibility, and file type in
+        // one stat call.  metadata() follows symlinks (matching fs::copy
+        // behaviour).  Dry-run is inherently best-effort — a file that passes
+        // here could still fail on the real run (e.g. no read permission) — but
+        // this covers the common cases the user needs to know about up front.
+        // Use println! so notices are always visible regardless of -q/--quiet.
+        match std::fs::metadata(source) {
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 println!("  {source} (not found — would be skipped)");
                 return Ok(false);
             }
-            Err(_) => {
-                println!("  {source} (not accessible — would be skipped)");
+            Err(err) => {
+                println!("  {source} (not accessible: {err} — would be skipped)");
                 return Ok(false);
             }
-            Ok(true) => {} // metadata accessible — show the preview arrow below
+            Ok(meta) if !meta.is_file() => {
+                println!("  {source} (not a regular file — would be skipped)");
+                return Ok(false);
+            }
+            Ok(_) => {} // regular file — show the preview arrow below
         }
         println!("  {source} {arrow} {target_display}");
         return Ok(true);
@@ -473,15 +485,18 @@ mod tests {
 
     #[test]
     fn validate_sources_empty_slice_returns_ok() {
+        // Use stop_on_error=true so the function enters the scanning loop
+        // (rather than hitting the early-return guard) and proves that an
+        // empty slice produces Ok(()) through the loop body.
         let opts = ProcessOptions {
             dry_run: false,
             move_files: false,
-            stop_on_error: false,
+            stop_on_error: true,
             show_detail_info: false,
         };
         assert!(
             validate_sources(&[], &opts).is_ok(),
-            "empty source list should return Ok"
+            "empty source list should return Ok even with stop_on_error=true"
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -104,14 +104,10 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
     // is inherent in any check-then-act design and is acceptable for the
     // single-user interactive use case this tool targets.
     if opts.stop_on_error && !opts.dry_run {
-        let list = missing
-            .iter()
-            .map(|p| format!("  {p}"))
-            .collect::<Vec<_>>()
-            .join("\n");
         anyhow::bail!(
-            "{} source file(s) not found:\n{list}\nHalting.",
-            missing.len()
+            "{} source file(s) not found:\n  {}\nHalting.",
+            missing.len(),
+            missing.join("\n  ")
         );
     }
 
@@ -140,9 +136,9 @@ pub fn process_file(
     };
 
     if opts.dry_run {
-        // Skip missing sources silently — validate_sources already warned about them
-        // before the loop started.  Printing an arrow here would give a false-safe
-        // picture: the real run would fail or skip the file, not copy it.
+        // Guard against missing sources: a file absent at dry-run time would not
+        // be copied in a real run either (TOCTOU notwithstanding).  Printing an
+        // arrow for a non-existent source would give a false-safe dry-run picture.
         if !std::path::Path::new(source).exists() {
             return Ok(false);
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -573,7 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_sources_missing_with_stop_on_error_returns_err() {
+    fn validate_sources_missing_returns_err() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let absent = dir.path().join("no_such_file.txt");
         let sources = [absent.to_str().expect("utf-8")];
@@ -585,20 +585,26 @@ mod tests {
 
 
     #[test]
-    fn validate_sources_multiple_missing_all_halt_on_stop_on_error() {
+    fn validate_sources_multiple_missing_reports_all() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let a = dir.path().join("missing_a.txt");
         let b = dir.path().join("missing_b.txt");
         let sources = [a.to_str().expect("utf-8"), b.to_str().expect("utf-8")];
         let result = validate_sources(&sources);
-        assert!(
-            result.is_err(),
-            "multiple missing paths + stop_on_error=true should return Err"
-        );
+        assert!(result.is_err(), "multiple missing paths should return Err");
         let msg = format!("{}", result.unwrap_err());
         assert!(
             msg.contains("2 source path(s) cannot be processed"),
-            "error message should contain '2 source path(s) cannot be processed'; got: {msg}"
+            "error message should contain count; got: {msg}"
+        );
+        // Both individual paths must be mentioned so the user sees the full picture.
+        assert!(
+            msg.contains(a.to_str().expect("utf-8")),
+            "error message must mention the first missing path; got: {msg}"
+        );
+        assert!(
+            msg.contains(b.to_str().expect("utf-8")),
+            "error message must mention the second missing path; got: {msg}"
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -146,12 +146,16 @@ pub fn process_file(
     };
 
     if opts.dry_run {
-        // Guard against inaccessible sources: a file absent or unreadable at
-        // dry-run time would not be copied in a real run either (TOCTOU
-        // notwithstanding).  Use try_exists() so permission errors are not
-        // silently misreported as "not found".  Use println! so the notice is
-        // always visible, matching the arrow line which also bypasses the logger
-        // (-q does not suppress it).
+        // Best-effort guard for the dry-run preview.  try_exists() checks
+        // whether the filesystem can retrieve the entry's metadata (a stat
+        // call).  Ok(false) means the entry is absent; Err means even the
+        // stat failed (e.g. search permission denied on the parent directory).
+        // Note: try_exists() returning Ok(true) does NOT guarantee the file is
+        // readable — a file that passes here could still fail to be copied if
+        // read permission is denied.  Dry-run is inherently best-effort; the
+        // real copy will surface any such permission error.  Use println! so
+        // the notice is always visible, matching the arrow lines which also
+        // bypass the logger (-q does not suppress them).
         match std::path::Path::new(source).try_exists() {
             Ok(false) => {
                 println!("  {source} (not found — would be skipped)");
@@ -161,7 +165,7 @@ pub fn process_file(
                 println!("  {source} (not accessible — would be skipped)");
                 return Ok(false);
             }
-            Ok(true) => {} // file exists — show the preview arrow below
+            Ok(true) => {} // metadata accessible — show the preview arrow below
         }
         println!("  {source} {arrow} {target_display}");
         return Ok(true);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -65,8 +65,8 @@ pub struct ProcessOptions {
 
 /// Pre-flight existence check: verify all source paths can be processed.
 ///
-/// Iterates over `sources` and checks each path for: (1) a valid filename
-/// component, (2) filesystem existence via `try_exists()`.  When
+/// Iterates over `sources` and calls `std::fs::metadata()` on each path to
+/// check existence, accessibility, and file type in one syscall.  When
 /// `stop_on_error` is `true` and `dry_run` is `false`, returns an error
 /// listing every problematic path so the user sees the complete picture in
 /// one message before any files are moved or copied.  In all other cases the
@@ -107,7 +107,7 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
         // denied); Ok + !is_file() → exists but is a directory, pipe, etc.
         match std::fs::metadata(s) {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                problems.push(s.to_string());
+                problems.push(format!("{s} (not found)"));
             }
             Err(err) => {
                 // OS-level error: add inline so the batch message shows all
@@ -182,21 +182,38 @@ pub fn process_file(
         return Ok(true);
     }
 
-    // Guard: source must be a regular file.  Without this, --move mode would
-    // silently succeed for a directory on Unix (fs::rename is directory-aware),
-    // contradicting the dry-run "(not a regular file — would be skipped)"
-    // notice and the tool's file-only semantics.  fs::copy returns EISDIR for
-    // directories, but being consistent across copy and move avoids surprises.
-    // If metadata() itself fails (source absent or inaccessible), we fall
-    // through and let fs::copy / fs::rename surface the OS error below.
-    if let Ok(meta) = std::fs::metadata(source) {
-        if !meta.is_file() {
+    // Guard: check source is a regular file before operating on it.
+    // Without this, --move mode would silently succeed for a directory on Unix
+    // (fs::rename is directory-aware), contradicting the dry-run preview and
+    // the tool's file-only semantics.  Handling Err cases here (absent,
+    // inaccessible) keeps the real-run messages consistent with dry-run, where
+    // the same conditions are also reported explicitly rather than deferred to
+    // fs::copy / fs::rename.  On a TOCTOU race (file disappears between this
+    // check and the copy), the copy will fail and the error is surfaced below.
+    match std::fs::metadata(source) {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // Absent file — consistent with dry-run "(not found)" notice.
+            // Fall through to fs::copy/rename which will produce an OS error;
+            // this mirrors the pre-flight path and avoids double-reporting.
+        }
+        Err(err) => {
+            // Inaccessible (e.g. permission denied on stat) — report now so
+            // the message matches the dry-run "(not accessible: …)" output.
+            if opts.stop_on_error {
+                return Err(anyhow::Error::from(err))
+                    .with_context(|| format!("'{source}' is not accessible"));
+            }
+            log::warn!("'{source}' is not accessible ({err}). Skipping.");
+            return Ok(false);
+        }
+        Ok(meta) if !meta.is_file() => {
             if opts.stop_on_error {
                 anyhow::bail!("'{source}' is not a regular file");
             }
             log::warn!("'{source}' is not a regular file. Skipping.");
             return Ok(false);
         }
+        Ok(_) => {} // regular file — proceed to copy/rename
     }
 
     log::debug!("{verb} {source} to {target_display}");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,13 +68,9 @@ pub struct ProcessOptions {
 /// Iterates over `sources` and collects every path that does not exist on disk.
 /// When `stop_on_error` is `true` and `dry_run` is `false`, returns an error
 /// listing all missing paths so the user sees the complete picture in one
-/// message before any files are moved or copied.  Otherwise returns `Ok(())`
-/// and missing files are reported individually as they are encountered in the
-/// processing loop.
-///
-/// When `stop_on_error` is `true` **and** `dry_run` is `false`, the function
-/// returns an error after reporting every missing path.  Dry-run is
-/// non-destructive, so it always warn-and-continues regardless of `stop_on_error`.
+/// message before any files are moved or copied.  In all other cases the
+/// function returns `Ok(())` without emitting any output; per-file feedback for
+/// missing sources is handled by `process_file` when the copy or move fails.
 ///
 /// # Returns
 ///
@@ -495,7 +491,7 @@ mod tests {
         };
         assert!(
             validate_sources(&sources, &opts).is_ok(),
-            "missing path + stop_on_error=false should return Ok (warn-and-continue)"
+            "missing path + stop_on_error=false should return Ok (per-file handling deferred to process_file)"
         );
     }
 
@@ -518,8 +514,8 @@ mod tests {
         );
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains('2'),
-            "error message should report the count (2); got: {msg}"
+            msg.contains("2 source file(s) not found"),
+            "error message should contain '2 source file(s) not found'; got: {msg}"
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,6 +63,55 @@ pub struct ProcessOptions {
     pub show_detail_info: bool,
 }
 
+/// Pre-flight existence check: report all missing source paths before processing.
+///
+/// Iterates over `sources` and collects every path that does not exist on disk.
+/// All missing paths are logged as warnings so the user sees the complete error
+/// picture before any files are moved or copied.
+///
+/// When `stop_on_error` is `true` **and** `dry_run` is `false`, the function
+/// returns an error after reporting every missing path.  Dry-run is
+/// non-destructive, so it always warn-and-continues regardless of `stop_on_error`.
+///
+/// # Returns
+///
+/// - `Ok(())` when all paths exist, or when the caller has opted out of hard
+///   errors (`stop_on_error = false`, or `dry_run = true`).
+/// - `Err(...)` when one or more paths are absent and `stop_on_error` is `true`
+///   and `dry_run` is `false`.
+pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Result<()> {
+    let missing: Vec<&str> = sources
+        .iter()
+        .copied()
+        .filter(|s| !std::path::Path::new(s).exists())
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    if opts.stop_on_error && !opts.dry_run {
+        // Include every missing path in the error message so it appears on
+        // stderr via the `eprintln!` in main().  This gives the caller a
+        // complete picture of all absent files in one fatal message.
+        let list = missing
+            .iter()
+            .map(|p| format!("  {p}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!(
+            "{} source file(s) not found:\n{list}\nHalting.",
+            missing.len()
+        );
+    }
+
+    for path in &missing {
+        log::warn!("Source file not found: {path}");
+    }
+
+    Ok(())
+}
+
 /// Process a single source file: dry-run preview, copy, or move.
 ///
 /// # Returns
@@ -116,7 +165,7 @@ pub fn process_file(
 
 #[cfg(test)]
 mod tests {
-    use super::{check_directory, log_level, process_file, ProcessOptions};
+    use super::{check_directory, log_level, process_file, validate_sources, ProcessOptions};
     use log::LevelFilter;
 
     // ---------------------------------------------------------------------------
@@ -335,6 +384,123 @@ mod tests {
         assert!(
             result.is_err(),
             "missing source (move) + stop_on_error=true should return Err"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // validate_sources
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn validate_sources_all_exist_returns_ok() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let f1 = dir.path().join("a.txt");
+        let f2 = dir.path().join("b.txt");
+        std::fs::write(&f1, b"").expect("write f1");
+        std::fs::write(&f2, b"").expect("write f2");
+        let sources = [
+            f1.to_str().expect("utf-8"),
+            f2.to_str().expect("utf-8"),
+        ];
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        assert!(
+            validate_sources(&sources, &opts).is_ok(),
+            "all paths exist — should return Ok"
+        );
+    }
+
+    #[test]
+    fn validate_sources_empty_slice_returns_ok() {
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        assert!(
+            validate_sources(&[], &opts).is_ok(),
+            "empty source list should return Ok"
+        );
+    }
+
+    #[test]
+    fn validate_sources_missing_with_stop_on_error_returns_err() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let absent = dir.path().join("no_such_file.txt");
+        let sources = [absent.to_str().expect("utf-8")];
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        assert!(
+            validate_sources(&sources, &opts).is_err(),
+            "missing path + stop_on_error=true should return Err"
+        );
+    }
+
+    #[test]
+    fn validate_sources_missing_without_stop_on_error_returns_ok() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let absent = dir.path().join("no_such_file.txt");
+        let sources = [absent.to_str().expect("utf-8")];
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        assert!(
+            validate_sources(&sources, &opts).is_ok(),
+            "missing path + stop_on_error=false should return Ok (warn-and-continue)"
+        );
+    }
+
+    #[test]
+    fn validate_sources_multiple_missing_all_halt_on_stop_on_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let a = dir.path().join("missing_a.txt");
+        let b = dir.path().join("missing_b.txt");
+        let sources = [a.to_str().expect("utf-8"), b.to_str().expect("utf-8")];
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        let result = validate_sources(&sources, &opts);
+        assert!(
+            result.is_err(),
+            "multiple missing paths + stop_on_error=true should return Err"
+        );
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains('2'),
+            "error message should report the count (2); got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_sources_dry_run_missing_with_stop_on_error_returns_ok() {
+        // dry-run is non-destructive — missing files should warn but not abort.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let absent = dir.path().join("no_such_file.txt");
+        let sources = [absent.to_str().expect("utf-8")];
+        let opts = ProcessOptions {
+            dry_run: true,
+            move_files: false,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        assert!(
+            validate_sources(&sources, &opts).is_ok(),
+            "dry-run + stop_on_error=true + missing path should still return Ok"
         );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -96,7 +96,7 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
     // is inherent in any check-then-act design and is acceptable for the
     // single-user interactive use case this tool targets.
     let mut missing: Vec<&str> = Vec::new();
-    for &s in sources.iter() {
+    for &s in sources {
         match std::path::Path::new(s).try_exists() {
             Ok(true) => {}  // file exists — nothing to do
             Ok(false) => missing.push(s),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -90,10 +90,20 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
         return Ok(());
     }
 
+    // In the hard-error (stop_on_error) case: include every missing path in the
+    // error message so it appears on stderr via the `eprintln!` in main().  This
+    // gives the caller the complete picture of all absent files in one fatal
+    // message before any files are moved or copied.
+    //
+    // Note: dry-run is non-destructive, so stop_on_error is suppressed for it —
+    // the loop's own dry-run output will show which files would be skipped.
+    //
+    // Note: a TOCTOU race exists between this check and the actual fs::copy /
+    // fs::rename in process_file.  A file deleted between the two points will
+    // produce a false-clean pre-flight followed by a mid-run copy error.  This
+    // is inherent in any check-then-act design and is acceptable for the
+    // single-user interactive use case this tool targets.
     if opts.stop_on_error && !opts.dry_run {
-        // Include every missing path in the error message so it appears on
-        // stderr via the `eprintln!` in main().  This gives the caller a
-        // complete picture of all absent files in one fatal message.
         let list = missing
             .iter()
             .map(|p| format!("  {p}"))
@@ -103,10 +113,6 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
             "{} source file(s) not found:\n{list}\nHalting.",
             missing.len()
         );
-    }
-
-    for path in &missing {
-        log::warn!("Source file not found: {path}");
     }
 
     Ok(())
@@ -134,6 +140,12 @@ pub fn process_file(
     };
 
     if opts.dry_run {
+        // Skip missing sources silently — validate_sources already warned about them
+        // before the loop started.  Printing an arrow here would give a false-safe
+        // picture: the real run would fail or skip the file, not copy it.
+        if !std::path::Path::new(source).exists() {
+            return Ok(false);
+        }
         println!("  {source} {arrow} {target_display}");
         return Ok(true);
     }
@@ -236,6 +248,28 @@ mod tests {
     // ---------------------------------------------------------------------------
     // process_file
     // ---------------------------------------------------------------------------
+
+    #[test]
+    fn process_file_dry_run_missing_source_returns_ok_false_without_creating_file() {
+        // A missing source in dry-run must return Ok(false) and NOT print an arrow —
+        // validate_sources already warned about it; showing a success-looking "==>" line
+        // would give a false-safe picture of what the real run would do.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("no_such_file.txt"); // intentionally absent
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: true,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src.to_str().expect("utf-8"), &tgt, &opts);
+        assert!(
+            !result.unwrap(),
+            "dry_run + missing source should return Ok(false)"
+        );
+        assert!(!tgt.exists(), "dry_run must not create the target file");
+    }
 
     #[test]
     fn process_file_dry_run_copy_returns_ok_true_without_creating_file() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,39 +79,49 @@ pub struct ProcessOptions {
 /// - `Err(...)` when one or more paths are absent and `stop_on_error` is `true`
 ///   and `dry_run` is `false`.
 pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Result<()> {
-    let missing: Vec<&str> = sources
-        .iter()
-        .copied()
-        .filter(|s| !std::path::Path::new(s).exists())
-        .collect();
-
-    if missing.is_empty() {
+    // Only meaningful in hard-error, non-dry-run mode.  The caller guards this,
+    // but the check is kept here too so the function is self-contained for tests.
+    if !opts.stop_on_error || opts.dry_run {
         return Ok(());
     }
 
-    // In the hard-error (stop_on_error) case: include every missing path in the
-    // error message so it appears on stderr via the `eprintln!` in main().  This
-    // gives the caller the complete picture of all absent files in one fatal
-    // message before any files are moved or copied.
-    //
-    // Note: dry-run is non-destructive, so stop_on_error is suppressed for it —
-    // process_file's dry-run guard prints a "(not found — would be skipped)"
-    // notice per missing file so the user still gets per-file feedback.
+    // Use try_exists() rather than exists() so that OS errors such as "permission
+    // denied" surface as immediate hard errors instead of being silently treated
+    // as "not found".  exists() returns false for *any* metadata failure; only
+    // Ok(false) from try_exists() means the file is genuinely absent.
     //
     // Note: a TOCTOU race exists between this check and the actual fs::copy /
     // fs::rename in process_file.  A file deleted between the two points will
     // produce a false-clean pre-flight followed by a mid-run copy error.  This
     // is inherent in any check-then-act design and is acceptable for the
     // single-user interactive use case this tool targets.
-    if opts.stop_on_error && !opts.dry_run {
-        anyhow::bail!(
-            "{} source file(s) not found:\n  {}\nHalting.",
-            missing.len(),
-            missing.join("\n  ")
-        );
+    let mut missing: Vec<&str> = Vec::new();
+    for &s in sources.iter() {
+        match std::path::Path::new(s).try_exists() {
+            Ok(true) => {}  // file exists — nothing to do
+            Ok(false) => missing.push(s),
+            Err(err) => {
+                // An OS-level error while probing existence (e.g. permission
+                // denied) will almost certainly prevent the copy/move from
+                // succeeding too; surface it immediately with context.
+                return Err(anyhow::Error::from(err))
+                    .with_context(|| format!("Unable to access source file '{s}'"));
+            }
+        }
     }
 
-    Ok(())
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    // Include every missing path in the error message so it appears on stderr
+    // via the `eprintln!` in main(), giving the user the full picture before any
+    // files are moved or copied.
+    anyhow::bail!(
+        "{} source file(s) not found:\n  {}\nHalting.",
+        missing.len(),
+        missing.join("\n  ")
+    );
 }
 
 /// Process a single source file: dry-run preview, copy, or move.
@@ -136,14 +146,22 @@ pub fn process_file(
     };
 
     if opts.dry_run {
-        // Guard against missing sources: a file absent at dry-run time would not
-        // be copied in a real run either (TOCTOU notwithstanding).  Printing an
-        // arrow for a non-existent source would give a false-safe dry-run picture.
-        // Use println! so the notice is always visible, matching the arrow line
-        // behaviour which also bypasses the logger (-q does not suppress it).
-        if !std::path::Path::new(source).exists() {
-            println!("  {source} (not found — would be skipped)");
-            return Ok(false);
+        // Guard against inaccessible sources: a file absent or unreadable at
+        // dry-run time would not be copied in a real run either (TOCTOU
+        // notwithstanding).  Use try_exists() so permission errors are not
+        // silently misreported as "not found".  Use println! so the notice is
+        // always visible, matching the arrow line which also bypasses the logger
+        // (-q does not suppress it).
+        match std::path::Path::new(source).try_exists() {
+            Ok(false) => {
+                println!("  {source} (not found — would be skipped)");
+                return Ok(false);
+            }
+            Err(_) => {
+                println!("  {source} (not accessible — would be skipped)");
+                return Ok(false);
+            }
+            Ok(true) => {} // file exists — show the preview arrow below
         }
         println!("  {source} {arrow} {target_display}");
         return Ok(true);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -91,8 +91,9 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
     }
 
     // Collect every problematic path so the user sees the full picture before
-    // any files are moved or copied.  OS errors are included inline rather than
-    // causing an immediate return — the message still lists all other issues.
+    // any files are moved or copied.  Use metadata() for a single syscall that
+    // checks existence, accessibility, and file type together — the same check
+    // that process_file uses so pre-flight and real-run are consistent.
     //
     // Note: a TOCTOU race exists between this check and the actual fs::copy /
     // fs::rename in process_file.  A file deleted between the two points will
@@ -101,24 +102,22 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
     // single-user interactive use case this tool targets.
     let mut problems: Vec<String> = Vec::new();
     for &s in sources {
-        // Paths with no filename component (e.g. ending in '/' or '..') are
-        // invalid regardless of existence; report them before stat'ing.
-        if std::path::Path::new(s).file_name().is_none() {
-            problems.push(format!("{s} (no filename component)"));
-            continue;
-        }
-        // Use try_exists() so that Ok(false) means "genuinely absent" while
-        // Err means "OS error" — exists() would return false for both cases,
-        // losing the distinction.
-        match std::path::Path::new(s).try_exists() {
-            Ok(true) => {}  // file accessible — nothing to do
-            Ok(false) => problems.push(s.to_string()),
+        // metadata() follows symlinks (matching fs::copy behaviour).
+        // NotFound → genuinely absent; other Err → OS error (e.g. permission
+        // denied); Ok + !is_file() → exists but is a directory, pipe, etc.
+        match std::fs::metadata(s) {
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                problems.push(s.to_string());
+            }
             Err(err) => {
-                // OS-level error (e.g. permission denied): add to the problem
-                // list rather than returning early so every unreachable path
-                // appears in one batch message.
+                // OS-level error: add inline so the batch message shows all
+                // issues rather than stopping at the first one.
                 problems.push(format!("{s} ({err})"));
             }
+            Ok(meta) if !meta.is_file() => {
+                problems.push(format!("{s} (not a regular file)"));
+            }
+            Ok(_) => {} // regular file — nothing to do
         }
     }
 
@@ -130,7 +129,7 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
     // via the `eprintln!` in main(), giving the user the full picture before
     // any files are moved or copied.
     anyhow::bail!(
-        "{} source file(s) not found:\n  {}\nHalting.",
+        "{} source path(s) cannot be processed:\n  {}\nHalting.",
         problems.len(),
         problems.join("\n  ")
     );
@@ -181,6 +180,23 @@ pub fn process_file(
         }
         println!("  {source} {arrow} {target_display}");
         return Ok(true);
+    }
+
+    // Guard: source must be a regular file.  Without this, --move mode would
+    // silently succeed for a directory on Unix (fs::rename is directory-aware),
+    // contradicting the dry-run "(not a regular file — would be skipped)"
+    // notice and the tool's file-only semantics.  fs::copy returns EISDIR for
+    // directories, but being consistent across copy and move avoids surprises.
+    // If metadata() itself fails (source absent or inaccessible), we fall
+    // through and let fs::copy / fs::rename surface the OS error below.
+    if let Ok(meta) = std::fs::metadata(source) {
+        if !meta.is_file() {
+            if opts.stop_on_error {
+                anyhow::bail!("'{source}' is not a regular file");
+            }
+            log::warn!("'{source}' is not a regular file. Skipping.");
+            return Ok(false);
+        }
     }
 
     log::debug!("{verb} {source} to {target_display}");
@@ -281,6 +297,72 @@ mod tests {
     // ---------------------------------------------------------------------------
     // process_file
     // ---------------------------------------------------------------------------
+
+    #[test]
+    fn process_file_directory_source_soft_error_returns_ok_false() {
+        // A directory passed as a source must be rejected with Ok(false) rather
+        // than silently moved (fs::rename on a directory succeeds on Unix and
+        // would move the whole tree, contradicting the dry-run preview).
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src_dir = tempfile::tempdir().expect("create source dir");
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src_dir.path().to_str().expect("utf-8"), &tgt, &opts);
+        assert!(
+            !result.expect("should return Ok, not Err, in soft-error mode"),
+            "directory source (copy, soft-error) should return Ok(false)"
+        );
+        assert!(!tgt.exists(), "no target should be created for a directory source");
+    }
+
+    #[test]
+    fn process_file_directory_source_move_soft_error_returns_ok_false() {
+        // Move mode is the critical case: fs::rename on a directory silently
+        // succeeds on Unix — without the is_file() guard the entire directory
+        // would be relocated to the target, which is never what the user wants.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src_dir = tempfile::tempdir().expect("create source dir");
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: true,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_file(src_dir.path().to_str().expect("utf-8"), &tgt, &opts);
+        assert!(
+            !result.expect("should return Ok, not Err, in soft-error mode"),
+            "directory source (move, soft-error) should return Ok(false)"
+        );
+        assert!(
+            src_dir.path().exists(),
+            "source directory must NOT be moved/renamed"
+        );
+    }
+
+    #[test]
+    fn process_file_directory_source_hard_error_returns_err() {
+        // With stop_on_error the is_file() guard must bail rather than returning Ok(false).
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src_dir = tempfile::tempdir().expect("create source dir");
+        let tgt = dir.path().join("out.txt");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        let result = process_file(src_dir.path().to_str().expect("utf-8"), &tgt, &opts);
+        assert!(
+            result.is_err(),
+            "directory source + stop_on_error=true should return Err"
+        );
+    }
 
     #[test]
     fn process_file_dry_run_missing_source_returns_ok_false_without_creating_file() {
@@ -553,8 +635,30 @@ mod tests {
         );
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("2 source file(s) not found"),
-            "error message should contain '2 source file(s) not found'; got: {msg}"
+            msg.contains("2 source path(s) cannot be processed"),
+            "error message should contain '2 source path(s) cannot be processed'; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_sources_directory_source_reports_not_regular_file() {
+        // A directory that exists should be rejected by the pre-flight check with
+        // "(not a regular file)" — not silently passed as "found" — so the user
+        // sees the problem before any other files are moved or copied.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let sources = [dir.path().to_str().expect("utf-8")];
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        let result = validate_sources(&sources, &opts);
+        assert!(result.is_err(), "a directory source + stop_on_error=true should return Err");
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("not a regular file"),
+            "error message should mention 'not a regular file'; got: {msg}"
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -104,7 +104,7 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
                 // An OS-level error while probing existence (e.g. permission
                 // denied) will almost certainly prevent the copy/move from
                 // succeeding too; surface it immediately with context.
-                return Err(anyhow::Error::from(err))
+                return Err(err)
                     .with_context(|| format!("Unable to access source file '{s}'"));
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,12 +66,9 @@ pub struct ProcessOptions {
 /// Pre-flight existence check: verify all source paths can be processed.
 ///
 /// Iterates over `sources` and calls `std::fs::metadata()` on each path to
-/// check existence, accessibility, and file type in one syscall.  When
-/// `stop_on_error` is `true` and `dry_run` is `false`, returns an error
-/// listing every problematic path so the user sees the complete picture in
-/// one message before any files are moved or copied.  In all other cases the
-/// function returns `Ok(())` without emitting any output; per-file feedback
-/// is handled by `process_file`.
+/// check existence, accessibility, and file type in one syscall.  Returns an
+/// error listing every problematic path so the user sees the complete picture
+/// in one message before any files are moved or copied.
 ///
 /// OS-level errors (e.g. permission denied) are collected into the same batch
 /// message rather than causing an immediate return, so all unreachable paths
@@ -79,17 +76,10 @@ pub struct ProcessOptions {
 ///
 /// # Returns
 ///
-/// - `Ok(())` when all paths are valid and exist, or when the caller has opted
-///   out of hard errors (`stop_on_error = false`, or `dry_run = true`).
-/// - `Err(...)` when one or more paths are problematic and `stop_on_error` is
-///   `true` and `dry_run` is `false`.
-pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Result<()> {
-    // Only meaningful in hard-error, non-dry-run mode; the function is
-    // self-contained so tests can call it directly with any option combination.
-    if !opts.stop_on_error || opts.dry_run {
-        return Ok(());
-    }
-
+/// - `Ok(())` when all source paths are regular files.
+/// - `Err(...)` when one or more paths are absent, inaccessible, or not a
+///   regular file.
+pub fn validate_sources(sources: &[&str]) -> anyhow::Result<()> {
     // Collect every problematic path so the user sees the full picture before
     // any files are moved or copied.  Use metadata() for a single syscall that
     // checks existence, accessibility, and file type together — the same check
@@ -568,34 +558,17 @@ mod tests {
             f1.to_str().expect("utf-8"),
             f2.to_str().expect("utf-8"),
         ];
-        // Use stop_on_error=true so the function actually performs the
-        // metadata() scan rather than returning early at the guard.
-        let opts = ProcessOptions {
-            dry_run: false,
-            move_files: false,
-            stop_on_error: true,
-            show_detail_info: false,
-        };
         assert!(
-            validate_sources(&sources, &opts).is_ok(),
-            "all paths exist — should return Ok even with stop_on_error=true"
+            validate_sources(&sources).is_ok(),
+            "all paths exist — should return Ok(())"
         );
     }
 
     #[test]
     fn validate_sources_empty_slice_returns_ok() {
-        // Use stop_on_error=true so the function enters the scanning loop
-        // (rather than hitting the early-return guard) and proves that an
-        // empty slice produces Ok(()) through the loop body.
-        let opts = ProcessOptions {
-            dry_run: false,
-            move_files: false,
-            stop_on_error: true,
-            show_detail_info: false,
-        };
         assert!(
-            validate_sources(&[], &opts).is_ok(),
-            "empty source list should return Ok even with stop_on_error=true"
+            validate_sources(&[]).is_ok(),
+            "empty source list should return Ok(())"
         );
     }
 
@@ -604,34 +577,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp dir");
         let absent = dir.path().join("no_such_file.txt");
         let sources = [absent.to_str().expect("utf-8")];
-        let opts = ProcessOptions {
-            dry_run: false,
-            move_files: false,
-            stop_on_error: true,
-            show_detail_info: false,
-        };
         assert!(
-            validate_sources(&sources, &opts).is_err(),
-            "missing path + stop_on_error=true should return Err"
+            validate_sources(&sources).is_err(),
+            "missing path should return Err"
         );
     }
 
-    #[test]
-    fn validate_sources_missing_without_stop_on_error_returns_ok() {
-        let dir = tempfile::tempdir().expect("create temp dir");
-        let absent = dir.path().join("no_such_file.txt");
-        let sources = [absent.to_str().expect("utf-8")];
-        let opts = ProcessOptions {
-            dry_run: false,
-            move_files: false,
-            stop_on_error: false,
-            show_detail_info: false,
-        };
-        assert!(
-            validate_sources(&sources, &opts).is_ok(),
-            "missing path + stop_on_error=false should return Ok (per-file handling deferred to process_file)"
-        );
-    }
 
     #[test]
     fn validate_sources_multiple_missing_all_halt_on_stop_on_error() {
@@ -639,13 +590,7 @@ mod tests {
         let a = dir.path().join("missing_a.txt");
         let b = dir.path().join("missing_b.txt");
         let sources = [a.to_str().expect("utf-8"), b.to_str().expect("utf-8")];
-        let opts = ProcessOptions {
-            dry_run: false,
-            move_files: false,
-            stop_on_error: true,
-            show_detail_info: false,
-        };
-        let result = validate_sources(&sources, &opts);
+        let result = validate_sources(&sources);
         assert!(
             result.is_err(),
             "multiple missing paths + stop_on_error=true should return Err"
@@ -664,13 +609,7 @@ mod tests {
         // sees the problem before any other files are moved or copied.
         let dir = tempfile::tempdir().expect("create temp dir");
         let sources = [dir.path().to_str().expect("utf-8")];
-        let opts = ProcessOptions {
-            dry_run: false,
-            move_files: false,
-            stop_on_error: true,
-            show_detail_info: false,
-        };
-        let result = validate_sources(&sources, &opts);
+        let result = validate_sources(&sources);
         assert!(result.is_err(), "a directory source + stop_on_error=true should return Err");
         let msg = format!("{}", result.unwrap_err());
         assert!(
@@ -679,21 +618,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn validate_sources_dry_run_missing_with_stop_on_error_returns_ok() {
-        // dry-run is non-destructive — missing files should warn but not abort.
-        let dir = tempfile::tempdir().expect("create temp dir");
-        let absent = dir.path().join("no_such_file.txt");
-        let sources = [absent.to_str().expect("utf-8")];
-        let opts = ProcessOptions {
-            dry_run: true,
-            move_files: false,
-            stop_on_error: true,
-            show_detail_info: false,
-        };
-        assert!(
-            validate_sources(&sources, &opts).is_ok(),
-            "dry-run + stop_on_error=true + missing path should still return Ok"
-        );
-    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -182,25 +182,25 @@ pub fn process_file(
         return Ok(true);
     }
 
-    // Guard: check source is a regular file before operating on it.
+    // Guard: check source exists and is a regular file before operating on it.
     // Without this, --move mode would silently succeed for a directory on Unix
     // (fs::rename is directory-aware), contradicting the dry-run preview and
-    // the tool's file-only semantics.  Handling Err cases here (absent,
-    // inaccessible) keeps the real-run messages consistent with dry-run, where
-    // the same conditions are also reported explicitly rather than deferred to
-    // fs::copy / fs::rename.  On a TOCTOU race (file disappears between this
-    // check and the copy), the copy will fail and the error is surfaced below.
+    // the tool's file-only semantics.  All error arms match the corresponding
+    // dry-run messages so the two modes report the same conditions consistently.
     match std::fs::metadata(source) {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            // Absent file — consistent with dry-run "(not found)" notice.
-            // Fall through to fs::copy/rename which will produce an OS error;
-            // this mirrors the pre-flight path and avoids double-reporting.
+            // Absent file — match dry-run "(not found — would be skipped)".
+            if opts.stop_on_error {
+                anyhow::bail!("'{source}' not found");
+            }
+            log::warn!("'{source}' not found. Skipping.");
+            return Ok(false);
         }
         Err(err) => {
             // Inaccessible (e.g. permission denied on stat) — report now so
             // the message matches the dry-run "(not accessible: …)" output.
             if opts.stop_on_error {
-                return Err(anyhow::Error::from(err))
+                return Err(err)
                     .with_context(|| format!("'{source}' is not accessible"));
             }
             log::warn!("'{source}' is not accessible ({err}). Skipping.");
@@ -569,7 +569,7 @@ mod tests {
             f2.to_str().expect("utf-8"),
         ];
         // Use stop_on_error=true so the function actually performs the
-        // try_exists() scan rather than returning early at the guard.
+        // metadata() scan rather than returning early at the guard.
         let opts = ProcessOptions {
             dry_run: false,
             move_files: false,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,8 +66,11 @@ pub struct ProcessOptions {
 /// Pre-flight existence check: report all missing source paths before processing.
 ///
 /// Iterates over `sources` and collects every path that does not exist on disk.
-/// All missing paths are logged as warnings so the user sees the complete error
-/// picture before any files are moved or copied.
+/// When `stop_on_error` is `true` and `dry_run` is `false`, returns an error
+/// listing all missing paths so the user sees the complete picture in one
+/// message before any files are moved or copied.  Otherwise returns `Ok(())`
+/// and missing files are reported individually as they are encountered in the
+/// processing loop.
 ///
 /// When `stop_on_error` is `true` **and** `dry_run` is `false`, the function
 /// returns an error after reporting every missing path.  Dry-run is
@@ -96,7 +99,8 @@ pub fn validate_sources(sources: &[&str], opts: &ProcessOptions) -> anyhow::Resu
     // message before any files are moved or copied.
     //
     // Note: dry-run is non-destructive, so stop_on_error is suppressed for it —
-    // the loop's own dry-run output will show which files would be skipped.
+    // process_file's dry-run guard prints a "(not found — would be skipped)"
+    // notice per missing file so the user still gets per-file feedback.
     //
     // Note: a TOCTOU race exists between this check and the actual fs::copy /
     // fs::rename in process_file.  A file deleted between the two points will
@@ -139,7 +143,10 @@ pub fn process_file(
         // Guard against missing sources: a file absent at dry-run time would not
         // be copied in a real run either (TOCTOU notwithstanding).  Printing an
         // arrow for a non-existent source would give a false-safe dry-run picture.
+        // Use println! so the notice is always visible, matching the arrow line
+        // behaviour which also bypasses the logger (-q does not suppress it).
         if !std::path::Path::new(source).exists() {
+            println!("  {source} (not found — would be skipped)");
             return Ok(false);
         }
         println!("  {source} {arrow} {target_display}");
@@ -247,9 +254,9 @@ mod tests {
 
     #[test]
     fn process_file_dry_run_missing_source_returns_ok_false_without_creating_file() {
-        // A missing source in dry-run must return Ok(false) and NOT print an arrow —
-        // validate_sources already warned about it; showing a success-looking "==>" line
-        // would give a false-safe picture of what the real run would do.
+        // A missing source in dry-run must return Ok(false) and print a "(not found)"
+        // notice instead of the success-looking "==>" arrow, which would give a false-safe
+        // picture of what the real run would do.
         let dir = tempfile::tempdir().expect("create temp dir");
         let src = dir.path().join("no_such_file.txt"); // intentionally absent
         let tgt = dir.path().join("out.txt");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -496,3 +496,50 @@ fn dry_run_missing_source_shows_not_found_notice() {
         "expected a 'not found' notice in dry-run stdout for a missing source; got:\n{stdout}"
     );
 }
+
+/// `--dry-run` combined with `--stop-on-error` must still produce the preview
+/// output and exit 0 — dry-run is a best-effort preview regardless of --stop.
+/// validate_sources is intentionally skipped in dry-run mode; per-file "(not
+/// found — would be skipped)" notices are shown instead of aborting.
+#[test]
+fn dry_run_with_stop_on_error_still_shows_preview() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst dir");
+
+    let real = tmp.path().join("real.txt");
+    fs::write(&real, b"data").expect("write real file");
+    let missing = tmp.path().join("missing.txt"); // intentionally never created
+
+    let output = Command::new(GATHER)
+        .arg("--dry-run")
+        .arg("--stop-on-error")
+        .arg(real.to_str().unwrap())
+        .arg(missing.to_str().unwrap())
+        .arg("-t")
+        .arg(&dst)
+        .output()
+        .expect("failed to run gather");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Dry-run must exit 0 even with --stop-on-error.
+    assert!(
+        output.status.success(),
+        "expected exit 0 (dry-run is best-effort preview); got {:?}
+stderr: {stderr}",
+        output.status,
+    );
+    // The missing file must appear in the preview with a "(not found)" notice.
+    assert!(
+        stdout.contains("not found"),
+        "expected '(not found)' in dry-run stdout for missing source; got:
+{stdout}"
+    );
+    // No files should have been created in the destination.
+    assert!(
+        !dst.join("real.txt").exists(),
+        "dry-run must not copy any files"
+    );
+}
+

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -330,3 +330,106 @@ fn move_error_message_contains_no_quotes() {
         "move error message must not contain quote characters; got:\n{stderr}"
     );
 }
+
+// -------------------------------------------------------------------
+// gtr-wek — pre-flight existence validation before the processing loop
+// -------------------------------------------------------------------
+
+/// With `--stop-on-error`, a missing source file must cause exit 1 with an
+/// error message on stderr *before* any other file is processed.
+#[test]
+fn preflight_missing_source_stop_on_error_exits_nonzero() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst dir");
+
+    // One real file + one absent file
+    let real = tmp.path().join("real.txt");
+    fs::write(&real, b"data").expect("write real file");
+
+    let output = Command::new(GATHER)
+        .arg("--stop-on-error")
+        .arg(real.to_str().unwrap())
+        .arg("gather_test_preflight_nosuchfile.txt") // guaranteed absent
+        .arg("-t")
+        .arg(&dst)
+        .output()
+        .expect("failed to run gather");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit when a source is missing with --stop-on-error; got 0\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.is_empty(),
+        "expected an error on stderr for missing source with --stop-on-error"
+    );
+}
+
+/// Without `--stop-on-error`, a missing source file should produce a warning
+/// on stdout but the process must still exit 0 and process the existing files.
+#[test]
+fn preflight_missing_source_without_stop_on_error_continues() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst dir");
+
+    let real = tmp.path().join("real.txt");
+    fs::write(&real, b"data").expect("write real file");
+
+    let output = Command::new(GATHER)
+        .arg(real.to_str().unwrap())
+        .arg("gather_test_preflight_nosuchfile.txt")
+        .arg("-t")
+        .arg(&dst)
+        .output()
+        .expect("failed to run gather");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 (continue mode) for missing source without --stop-on-error; got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // The real file must have been copied despite the missing one
+    assert!(
+        dst.join("real.txt").exists(),
+        "real.txt must be copied even when another source is missing"
+    );
+}
+
+/// With `--stop-on-error` and multiple missing files, ALL missing paths must
+/// be reported in the pre-flight pass (not just the first one).
+#[test]
+fn preflight_multiple_missing_all_reported_with_stop_on_error() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst dir");
+
+    let output = Command::new(GATHER)
+        .arg("--stop-on-error")
+        .arg("gather_preflight_absent_alpha.txt")
+        .arg("gather_preflight_absent_beta.txt")
+        .arg("-t")
+        .arg(&dst)
+        .output()
+        .expect("failed to run gather");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Both missing filenames must appear somewhere in stderr output
+    assert!(
+        stderr.contains("gather_preflight_absent_alpha.txt"),
+        "stderr must mention the first missing file; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("gather_preflight_absent_beta.txt"),
+        "stderr must mention the second missing file; got:\n{stderr}"
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit when sources are missing with --stop-on-error"
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -433,3 +433,29 @@ fn preflight_multiple_missing_all_reported_with_stop_on_error() {
         "expected non-zero exit when sources are missing with --stop-on-error"
     );
 }
+
+/// `--dry-run` with a missing source file must print a "(not found)" notice on
+/// stdout so the user knows which files would be skipped — the summary alone
+/// ("Files skipped due to errors: 1") provides no filename.
+#[test]
+fn dry_run_missing_source_shows_not_found_notice() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&dst).expect("create dst dir");
+
+    let stdout = run_gather(&[
+        "--dry-run",
+        "gather_dryrun_absent_source_xyz.txt", // guaranteed absent
+        "-t",
+        dst.to_str().unwrap(),
+    ]);
+
+    assert!(
+        stdout.contains("gather_dryrun_absent_source_xyz.txt"),
+        "expected the missing filename to appear in dry-run stdout; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("not found"),
+        "expected a 'not found' notice in dry-run stdout for a missing source; got:\n{stdout}"
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -358,15 +358,26 @@ fn preflight_missing_source_stop_on_error_exits_nonzero() {
         .output()
         .expect("failed to run gather");
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert_ne!(
         output.status.code(),
         Some(0),
         "expected non-zero exit when a source is missing with --stop-on-error; got 0\nstderr: {stderr}"
     );
+    // The fatal error must name the missing path and appear on stderr.
     assert!(
-        !stderr.is_empty(),
-        "expected an error on stderr for missing source with --stop-on-error"
+        stderr.contains(missing.to_str().unwrap()),
+        "expected missing path in stderr; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("not found"),
+        "expected 'not found' in stderr; got:\n{stderr}"
+    );
+    // No normal processing output should appear on stdout.
+    assert!(
+        stdout.is_empty(),
+        "expected stdout to be empty when pre-flight aborts; got:\n{stdout}"
     );
     assert!(
         !dst.join("real.txt").exists(),
@@ -394,13 +405,29 @@ fn preflight_missing_source_without_stop_on_error_continues() {
         .output()
         .expect("failed to run gather");
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         output.status.success(),
-        "expected exit 0 (continue mode) for missing source without --stop-on-error; got {:?}\nstderr: {}",
+        "expected exit 0 (continue mode) for missing source without --stop-on-error; got {:?}\nstderr: {stderr}",
         output.status,
-        String::from_utf8_lossy(&output.stderr)
     );
-    // The real file must have been copied despite the missing one
+    // The warning must mention the missing path and "not found" on stdout
+    // (the logger is configured with Target::Stdout).
+    assert!(
+        stdout.contains(missing.to_str().unwrap()),
+        "expected missing path in stdout warning; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("not found"),
+        "expected 'not found' in stdout warning; got:\n{stdout}"
+    );
+    // Nothing should have been written to stderr in continue mode.
+    assert!(
+        stderr.is_empty(),
+        "expected stderr to be empty in continue mode; got:\n{stderr}"
+    );
+    // The real file must have been copied despite the missing one.
     assert!(
         dst.join("real.txt").exists(),
         "real.txt must be copied even when another source is missing"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -336,21 +336,23 @@ fn move_error_message_contains_no_quotes() {
 // -------------------------------------------------------------------
 
 /// With `--stop-on-error`, a missing source file must cause exit 1 with an
-/// error message on stderr *before* any other file is processed.
+/// error message on stderr *before* any other file is processed.  The real
+/// file must NOT be copied — the pre-flight pass aborts before any I/O.
 #[test]
 fn preflight_missing_source_stop_on_error_exits_nonzero() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&dst).expect("create dst dir");
 
-    // One real file + one absent file
+    // One real file + one absent file (tempdir-scoped to guarantee absence).
     let real = tmp.path().join("real.txt");
     fs::write(&real, b"data").expect("write real file");
+    let missing = tmp.path().join("missing.txt"); // intentionally never created
 
     let output = Command::new(GATHER)
         .arg("--stop-on-error")
         .arg(real.to_str().unwrap())
-        .arg("gather_test_preflight_nosuchfile.txt") // guaranteed absent
+        .arg(missing.to_str().unwrap())
         .arg("-t")
         .arg(&dst)
         .output()
@@ -366,6 +368,10 @@ fn preflight_missing_source_stop_on_error_exits_nonzero() {
         !stderr.is_empty(),
         "expected an error on stderr for missing source with --stop-on-error"
     );
+    assert!(
+        !dst.join("real.txt").exists(),
+        "real.txt must NOT be copied when pre-flight aborts before processing"
+    );
 }
 
 /// Without `--stop-on-error`, a missing source file should produce a warning
@@ -378,10 +384,11 @@ fn preflight_missing_source_without_stop_on_error_continues() {
 
     let real = tmp.path().join("real.txt");
     fs::write(&real, b"data").expect("write real file");
+    let missing = tmp.path().join("missing.txt"); // intentionally never created
 
     let output = Command::new(GATHER)
         .arg(real.to_str().unwrap())
-        .arg("gather_test_preflight_nosuchfile.txt")
+        .arg(missing.to_str().unwrap())
         .arg("-t")
         .arg(&dst)
         .output()
@@ -408,23 +415,27 @@ fn preflight_multiple_missing_all_reported_with_stop_on_error() {
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&dst).expect("create dst dir");
 
+    // Tempdir-scoped paths guarantee absence without relying on the working directory.
+    let missing_a = tmp.path().join("absent_alpha.txt"); // intentionally never created
+    let missing_b = tmp.path().join("absent_beta.txt"); // intentionally never created
+
     let output = Command::new(GATHER)
         .arg("--stop-on-error")
-        .arg("gather_preflight_absent_alpha.txt")
-        .arg("gather_preflight_absent_beta.txt")
+        .arg(missing_a.to_str().unwrap())
+        .arg(missing_b.to_str().unwrap())
         .arg("-t")
         .arg(&dst)
         .output()
         .expect("failed to run gather");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // Both missing filenames must appear somewhere in stderr output
+    // Both missing absolute paths must appear somewhere in stderr output.
     assert!(
-        stderr.contains("gather_preflight_absent_alpha.txt"),
+        stderr.contains(missing_a.to_str().unwrap()),
         "stderr must mention the first missing file; got:\n{stderr}"
     );
     assert!(
-        stderr.contains("gather_preflight_absent_beta.txt"),
+        stderr.contains(missing_b.to_str().unwrap()),
         "stderr must mention the second missing file; got:\n{stderr}"
     );
     assert_ne!(
@@ -443,16 +454,15 @@ fn dry_run_missing_source_shows_not_found_notice() {
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&dst).expect("create dst dir");
 
-    let stdout = run_gather(&[
-        "--dry-run",
-        "gather_dryrun_absent_source_xyz.txt", // guaranteed absent
-        "-t",
-        dst.to_str().unwrap(),
-    ]);
+    // Tempdir-scoped path guarantees absence without relying on the working directory.
+    let missing = tmp.path().join("absent_source.txt"); // intentionally never created
+    let missing_str = missing.to_str().unwrap();
+
+    let stdout = run_gather(&["--dry-run", missing_str, "-t", dst.to_str().unwrap()]);
 
     assert!(
-        stdout.contains("gather_dryrun_absent_source_xyz.txt"),
-        "expected the missing filename to appear in dry-run stdout; got:\n{stdout}"
+        stdout.contains(missing_str),
+        "expected the missing absolute path to appear in dry-run stdout; got:\n{stdout}"
     );
     assert!(
         stdout.contains("not found"),


### PR DESCRIPTION
## Summary

- Adds a `validate_sources` pre-flight pass that checks all source paths with `Path::exists()` before the processing loop begins
- With `--stop-on-error`: all missing paths are listed in a fatal message on stderr and the program exits before touching any files
- Without `--stop-on-error`: the existing per-file error handling in `process_file` handles missing files naturally (no double-warnings)
- `--dry-run` with missing sources: now correctly returns `Ok(false)` and counts the file as skipped rather than printing a false "==> would be processed" arrow
- 9 new unit tests + 3 new CLI integration tests

## Test plan

- [ ] `cargo test` — all 42 tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `gather /nonexistent.txt -t /tmp --stop-on-error` → exits 1, error lists the missing path on stderr
- [ ] Manual: `gather /nonexistent.txt -t /tmp` → exits 0, skips the file, processes others
- [ ] Manual: `gather --dry-run /nonexistent.txt -t /tmp` → no arrow printed, file counted as skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)