### PR TITLE
feat: parallelize file operations with rayon (gtr-4ee)

### DIFF
--- a/.crumbs/add-integration-test-for-serial-flag-end-to-end.md
+++ b/.crumbs/add-integration-test-for-serial-flag-end-to-end.md
@@ -1,0 +1,17 @@
+---
+id: gtr-1a5
+title: Add integration test for --serial flag end-to-end
+status: open
+type: feature
+priority: 3
+tags:
+- gather
+- testing
+created: 2026-07-04
+updated: 2026-07-04
+phase: ''
+---
+
+# Add integration test for --serial flag end-to-end
+
+The --serial / -1 flag is unit-tested for CLI parsing but has no integration test that runs the binary and confirms files are actually copied in serial mode. Add a tests/cli.rs test using assert_cmd or similar.

--- a/.crumbs/detect-same-basename-collisions-at-target.md
+++ b/.crumbs/detect-same-basename-collisions-at-target.md
@@ -1,0 +1,17 @@
+---
+id: gtr-h5k
+title: Detect same-basename collisions at target
+status: open
+type: feature
+priority: 3
+tags:
+- gather
+- correctness
+created: 2026-07-04
+updated: 2026-07-04
+phase: ''
+---
+
+# Detect same-basename collisions at target
+
+When two source files share the same basename (e.g. /a/report.pdf and /b/report.pdf), the second silently overwrites the first at the target with no warning. Pre-existing in serial mode; a race in parallel mode. Add collision detection before writing (or at minimum a warning).

--- a/.crumbs/parallelize.md
+++ b/.crumbs/parallelize.md
@@ -1,15 +1,20 @@
 ---
 id: gtr-4ee
 title: Parallelize
-status: open
+status: closed
 type: feature
 priority: 3
 tags: []
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-07-04
+closed_reason: 'Implemented in PR #85 — par_iter() parallelism with --serial/-1 fallback, stop-on-error semantics preserved on serial path, dry-run forced serial for ordered output'
 phase: ''
 ---
 
 # Parallelize
 
 Use par_iter() to parallelize the act of copying or moving files. Add a -1 parameter to remain serial.
+
+[start] 2026-07-04 08:30:14
+
+[stop]  2026-07-04 09:20:13  49m 59s

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,12 +197,13 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gather"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
  "env_logger",
  "log",
+ "rayon",
  "tempfile",
 ]
 
@@ -353,6 +385,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gather"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gather"
-version = "0.3.2"
+version = "0.4.0"
 description = "Gathers files from directories and subdirectories into a target directory."
 license = "Apache-2.0"
 authors = ["evensolberg <even.solberg@gmail.com>"]
@@ -16,6 +16,7 @@ anyhow = "1"
 clap = { version = "4.6.1", features = ["cargo", "env", "wrap_help"] }
 env_logger = "0.11.10"
 log = "0.4.32"
+rayon = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gather"
-version = "0.4.0"
+version = "0.5.0"
 description = "Gathers files from directories and subdirectories into a target directory."
 license = "Apache-2.0"
 authors = ["evensolberg <even.solberg@gmail.com>"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,13 @@ fn build_command() -> Command {
                 .help("Don't print detailed information about each file processed.")
                 .action(ArgAction::SetTrue)
         )
+        .arg( // Serial (non-parallel) processing
+            Arg::new("serial")
+                .short('1')
+                .long("serial")
+                .help("Process files serially instead of in parallel.")
+                .action(ArgAction::SetTrue)
+        )
 }
 
 #[cfg(test)]
@@ -116,6 +123,39 @@ mod tests {
         assert_eq!(
             matches.get_one::<String>("target").map(String::as_str),
             Some("/tmp/out")
+        );
+    }
+
+    #[test]
+    fn serial_flag_defaults_to_false() {
+        let matches = build_command()
+            .try_get_matches_from(["gather", "file.txt"])
+            .expect("parsing should succeed without --serial");
+        assert!(
+            !matches.get_flag("serial"),
+            "serial should default to false when flag is omitted"
+        );
+    }
+
+    #[test]
+    fn serial_flag_set_by_long_form() {
+        let matches = build_command()
+            .try_get_matches_from(["gather", "file.txt", "--serial"])
+            .expect("parsing should succeed with --serial");
+        assert!(
+            matches.get_flag("serial"),
+            "--serial should set the serial flag to true"
+        );
+    }
+
+    #[test]
+    fn serial_flag_set_by_short_form() {
+        let matches = build_command()
+            .try_get_matches_from(["gather", "file.txt", "-1"])
+            .expect("parsing should succeed with -1");
+        assert!(
+            matches.get_flag("serial"),
+            "-1 should set the serial flag to true"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,7 +39,7 @@ fn build_command() -> Command {
             Arg::new("stop")
                 .short('s')
                 .long("stop-on-error")
-                .help("Stop on error. If this flag isn't set, the application will attempt to continue in case of error.")
+                .help("Stop on error. Combine with --serial for true halt-on-first-error; in parallel mode, in-flight operations always complete before the error is reported.")
                 .action(ArgAction::SetTrue)
         )
         .arg( // Dry-run

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod cli;
 mod utils;
 
-use std::path::Path;
+use rayon::prelude::*;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// This is where the magic happens.
@@ -35,13 +35,15 @@ fn run() -> anyhow::Result<()> {
         show_detail_info: !cli_args.get_flag("detail-off"),
     };
     let print_summary = cli_args.get_flag("summary");
+    let serial = cli_args.get_flag("serial");
     log::debug!(
-        "dry_run: {}, move_files: {}, stop_on_error: {}, show_detail_info: {}, print_summary: {}",
+        "dry_run: {}, move_files: {}, stop_on_error: {}, show_detail_info: {}, print_summary: {}, serial: {}",
         opts.dry_run,
         opts.move_files,
         opts.stop_on_error,
         opts.show_detail_info,
-        print_summary
+        print_summary,
+        serial,
     );
 
     if opts.dry_run {
@@ -58,38 +60,32 @@ fn run() -> anyhow::Result<()> {
         utils::validate_sources(&sources)?;
     }
 
-    let mut total_file_count: usize = 0;
+    // Process files — in parallel by default, serially when --serial / -1 is set.
+    // Collect all results first so counters are accumulated after all I/O completes.
+    // Both paths call the same process_source function; only the iterator differs.
+    let results: Vec<anyhow::Result<bool>> = if serial {
+        sources
+            .iter()
+            .map(|&source| utils::process_source(source, target_dir, &opts))
+            .collect()
+    } else {
+        sources
+            .par_iter()
+            .map(|&source| utils::process_source(source, target_dir, &opts))
+            .collect()
+    };
+
+    let total_file_count = results.len();
     let mut processed_file_count: usize = 0;
     let mut skipped_file_count: usize = 0;
 
-    // Gather files
-    for source in sources.iter().copied() {
-        total_file_count += 1;
-
-        // Path::file_name() returns None when the last path component is ".."
-        // (Component::ParentDir, e.g. "foo/..") or the path is the root "/"
-        // (Component::RootDir) — neither has a usable target filename.
-        // In soft-error mode validate_sources is not called, so this guard is
-        // the sole protection; in stop_on_error mode validate_sources will
-        // have already rejected such paths (e.g. as not found, not a regular
-        // file, or inaccessible), making the bail! branch a defensive fallback.
-        let Some(file_name) = Path::new(source).file_name() else {
-            if opts.stop_on_error {
-                anyhow::bail!("Invalid filename in path: {source}. Halting.");
-            }
-            log::warn!("Invalid filename in path: {source}. Continuing.");
-            skipped_file_count += 1;
-            continue;
-        };
-
-        let new_filename = Path::new(target_dir).join(file_name);
-
-        if utils::process_file(source, &new_filename, &opts)? {
+    for result in results {
+        if result? {
             processed_file_count += 1;
         } else {
             skipped_file_count += 1;
         }
-    } // for source
+    }
 
     if print_summary {
         // Write directly to stdout so the summary is never silenced by -q/--quiet.

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,27 +73,26 @@ fn run() -> anyhow::Result<()> {
     //   is eager and non-short-circuiting, so --stop-on-error cannot abort in-flight
     //   operations; it surfaces the first Err after all workers complete.  For true
     //   halt-on-first-error semantics combine --serial with --stop.
-    let (total_file_count, processed_file_count, skipped_file_count) = if serial || opts.dry_run {
-        let mut total = 0usize;
-        let mut processed = 0usize;
-        let mut skipped = 0usize;
+    // Every source produces exactly one outcome, so total is known up front.
+    let total_file_count = sources.len();
+    let (processed_file_count, skipped_file_count) = if serial || opts.dry_run {
+        let mut processed = 0;
+        let mut skipped = 0;
         for &source in &sources {
-            total += 1;
             if utils::process_source(source, target_dir, &opts)? {
                 processed += 1;
             } else {
                 skipped += 1;
             }
         }
-        (total, processed, skipped)
+        (processed, skipped)
     } else {
         let results: Vec<anyhow::Result<bool>> = sources
             .par_iter()
             .map(|&source| utils::process_source(source, target_dir, &opts))
             .collect();
-        let total = results.len();
-        let mut processed = 0usize;
-        let mut skipped = 0usize;
+        let mut processed = 0;
+        let mut skipped = 0;
         for result in results {
             if result? {
                 processed += 1;
@@ -101,7 +100,7 @@ fn run() -> anyhow::Result<()> {
                 skipped += 1;
             }
         }
-        (total, processed, skipped)
+        (processed, skipped)
     };
 
     if print_summary {

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,32 +60,49 @@ fn run() -> anyhow::Result<()> {
         utils::validate_sources(&sources)?;
     }
 
-    // Process files — in parallel by default, serially when --serial / -1 is set.
-    // Collect all results first so counters are accumulated after all I/O completes.
-    // Both paths call the same process_source function; only the iterator differs.
-    let results: Vec<anyhow::Result<bool>> = if serial {
-        sources
-            .iter()
-            .map(|&source| utils::process_source(source, target_dir, &opts))
-            .collect()
+    // Process files in parallel by default, serially when --serial/-1 is set.
+    //
+    // Serial path (including dry-run):
+    //   A plain for-loop with ? inside so --stop-on-error short-circuits on the
+    //   first error without touching remaining files.  Dry-run always runs serially
+    //   so preview lines appear in input order, which matters for auditing an
+    //   ordered file list.
+    //
+    // Parallel path:
+    //   par_iter().collect() dispatches all workers concurrently.  collect::<Vec<Result>>
+    //   is eager and non-short-circuiting, so --stop-on-error cannot abort in-flight
+    //   operations; it surfaces the first Err after all workers complete.  For true
+    //   halt-on-first-error semantics combine --serial with --stop.
+    let (total_file_count, processed_file_count, skipped_file_count) = if serial || opts.dry_run {
+        let mut total = 0usize;
+        let mut processed = 0usize;
+        let mut skipped = 0usize;
+        for &source in &sources {
+            total += 1;
+            if utils::process_source(source, target_dir, &opts)? {
+                processed += 1;
+            } else {
+                skipped += 1;
+            }
+        }
+        (total, processed, skipped)
     } else {
-        sources
+        let results: Vec<anyhow::Result<bool>> = sources
             .par_iter()
             .map(|&source| utils::process_source(source, target_dir, &opts))
-            .collect()
-    };
-
-    let total_file_count = results.len();
-    let mut processed_file_count: usize = 0;
-    let mut skipped_file_count: usize = 0;
-
-    for result in results {
-        if result? {
-            processed_file_count += 1;
-        } else {
-            skipped_file_count += 1;
+            .collect();
+        let total = results.len();
+        let mut processed = 0usize;
+        let mut skipped = 0usize;
+        for result in results {
+            if result? {
+                processed += 1;
+            } else {
+                skipped += 1;
+            }
         }
-    }
+        (total, processed, skipped)
+    };
 
     if print_summary {
         // Write directly to stdout so the summary is never silenced by -q/--quiet.

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,10 @@ fn run() -> anyhow::Result<()> {
             .collect();
         let mut processed = 0;
         let mut skipped = 0;
+        // Drain results in order. On --stop-on-error the first Err propagates
+        // via ? and exits run() before the summary block is reached, so any
+        // remaining Ok(false) entries are never counted — an accepted artifact
+        // of parallel dispatch (all workers already completed by this point).
         for result in results {
             if result? {
                 processed += 1;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -231,9 +231,38 @@ pub fn process_file(
     }
 }
 
+/// Process one source path: resolve a usable filename, build the target path,
+/// then delegate to [`process_file`].
+///
+/// Isolating this logic from the main loop makes it callable from both a
+/// serial iterator and a parallel Rayon iterator without duplicating the
+/// filename-extraction guard.
+///
+/// # Returns
+///
+/// - `Ok(true)`  — the file was processed (copied or moved).
+/// - `Ok(false)` — the path was skipped (invalid filename or soft file error).
+/// - `Err(...)`  — a hard error occurred and `stop_on_error` is `true`.
+pub fn process_source(
+    source: &str,
+    target_dir: &str,
+    opts: &ProcessOptions,
+) -> anyhow::Result<bool> {
+    let Some(file_name) = std::path::Path::new(source).file_name() else {
+        if opts.stop_on_error {
+            anyhow::bail!("Invalid filename in path: {source}. Halting.");
+        }
+        log::warn!("Invalid filename in path: {source}. Continuing.");
+        return Ok(false);
+    };
+
+    let new_filename = std::path::Path::new(target_dir).join(file_name);
+    process_file(source, &new_filename, opts)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{check_directory, log_level, process_file, validate_sources, ProcessOptions};
+    use super::{check_directory, log_level, process_file, process_source, validate_sources, ProcessOptions};
     use log::LevelFilter;
 
     // ---------------------------------------------------------------------------
@@ -622,6 +651,68 @@ mod tests {
             msg.contains("not a regular file"),
             "error message should mention 'not a regular file'; got: {msg}"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // process_source
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn process_source_invalid_path_soft_error_returns_ok_false() {
+        // A path whose last component is ".." has no usable filename.
+        // In soft-error mode this must skip silently (Ok(false)) rather than panic.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        // "somedir/.." has no file_name() component.
+        let bad_path = format!("{}/..",&dir.path().display());
+        let result = process_source(&bad_path, dir.path().to_str().expect("utf-8"), &opts);
+        assert!(
+            !result.expect("soft-error invalid path should return Ok, not Err"),
+            "invalid path in soft-error mode should return Ok(false)"
+        );
+    }
+
+    #[test]
+    fn process_source_invalid_path_hard_error_returns_err() {
+        // With stop_on_error the invalid-path case must bail rather than Ok(false).
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: true,
+            show_detail_info: false,
+        };
+        let bad_path = format!("{}/..",&dir.path().display());
+        let result = process_source(&bad_path, dir.path().to_str().expect("utf-8"), &opts);
+        assert!(result.is_err(), "invalid path + stop_on_error=true should return Err");
+    }
+
+    #[test]
+    fn process_source_valid_file_copy_succeeds() {
+        // process_source with a normal file delegates to process_file and copies it.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src = dir.path().join("in.txt");
+        std::fs::write(&src, b"hello").expect("write src");
+        let target_dir = tempfile::tempdir().expect("create target dir");
+        let opts = ProcessOptions {
+            dry_run: false,
+            move_files: false,
+            stop_on_error: false,
+            show_detail_info: false,
+        };
+        let result = process_source(
+            src.to_str().expect("utf-8"),
+            target_dir.path().to_str().expect("utf-8"),
+            &opts,
+        );
+        assert!(result.expect("valid copy should return Ok"), "valid copy should return Ok(true)");
+        assert!(target_dir.path().join("in.txt").exists(), "copy must create target file");
+        assert!(src.exists(), "copy must not remove source file");
     }
 
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -250,9 +250,9 @@ pub fn process_source(
 ) -> anyhow::Result<bool> {
     let Some(file_name) = std::path::Path::new(source).file_name() else {
         if opts.stop_on_error {
-            anyhow::bail!("Invalid filename in path: {source}. Halting.");
+            anyhow::bail!("Invalid filename in path: '{source}'. Halting.");
         }
-        log::warn!("Invalid filename in path: {source}. Continuing.");
+        log::warn!("Invalid filename in path: '{source}'. Continuing.");
         return Ok(false);
     };
 
@@ -660,7 +660,7 @@ mod tests {
     #[test]
     fn process_source_invalid_path_soft_error_returns_ok_false() {
         // A path whose last component is ".." has no usable filename.
-        // In soft-error mode this must skip silently (Ok(false)) rather than panic.
+        // In soft-error mode this must return Ok(false) (logging a warning) rather than panic.
         let dir = tempfile::tempdir().expect("create temp dir");
         let opts = ProcessOptions {
             dry_run: false,


### PR DESCRIPTION
## Summary

- Uses `par_iter()` from Rayon to copy/move files concurrently by default
- New `--serial` / `-1` flag falls back to sequential processing for ordered or resource-constrained runs
- Extracts `utils::process_source` — the per-file loop body — so the same logic is reachable from both the serial and parallel paths
- Serial path (and `--dry-run`) use a plain `for` loop with `?` inside, preserving `--stop-on-error` short-circuit semantics and deterministic preview output
- Parallel path collects all results before draining; documents that `--stop` cannot abort in-flight workers (users needing true halt-on-first-error should combine `--serial --stop`)

## Test plan

- [x] Three new CLI flag tests: `serial_flag_defaults_to_false`, `serial_flag_set_by_long_form`, `serial_flag_set_by_short_form`
- [x] Three new `process_source` unit tests: invalid path soft-error, invalid path hard-error, valid file copy
- [x] All 52 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)